### PR TITLE
Add offline setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This project uses Gradle with Kotlin support.
 - **Java 9** or higher (toolchain target is 9)
 - **Kotlin 1.9.x** (handled by Gradle)
 
+## Setup
+
+Run the helper script to fetch IntelliJ dependencies and build offline:
+
+```bash
+./setup.sh
+```
+
+If the downloads are blocked, place the required files inside `local-repo`
+and rerun the script.
+
 ## Building
 Run the following command with your system-installed Gradle:
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# This script prepares an offline Gradle cache with the IntelliJ dependencies
+# required to build the project. It downloads the IntelliJ IDEA binaries and
+# the IntelliJ Gradle plugin then runs the build in offline mode.
+#
+# If downloads fail due to network restrictions, manually place the required
+# files in the local-repo directory before running the build.
+
+INTELLIJ_VERSION=2023.1
+INTELLIJ_URL="https://cache-redirector.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/${INTELLIJ_VERSION}/ideaIC-${INTELLIJ_VERSION}.zip"
+
+INTELLIJ_PLUGIN_VERSION=1.17.3
+INTELLIJ_PLUGIN_URL="https://plugins.gradle.org/m2/org/jetbrains/intellij/org.jetbrains.intellij.gradle.plugin/${INTELLIJ_PLUGIN_VERSION}/org.jetbrains.intellij.gradle.plugin-${INTELLIJ_PLUGIN_VERSION}.jar"
+
+LOCAL_REPO="local-repo"
+mkdir -p "$LOCAL_REPO"
+
+if [ ! -f "$LOCAL_REPO/ideaIC-${INTELLIJ_VERSION}.zip" ]; then
+  echo "Downloading IntelliJ IDEA ${INTELLIJ_VERSION}..."
+  curl -L -o "$LOCAL_REPO/ideaIC-${INTELLIJ_VERSION}.zip" "$INTELLIJ_URL"
+fi
+
+if [ ! -f "$LOCAL_REPO/org.jetbrains.intellij.gradle.plugin-${INTELLIJ_PLUGIN_VERSION}.jar" ]; then
+  echo "Downloading IntelliJ Gradle plugin ${INTELLIJ_PLUGIN_VERSION}..."
+  curl -L -o "$LOCAL_REPO/org.jetbrains.intellij.gradle.plugin-${INTELLIJ_PLUGIN_VERSION}.jar" "$INTELLIJ_PLUGIN_URL"
+fi
+
+echo "Running Gradle build in offline mode..."
+gradle --offline -Dmaven.repo.local="$LOCAL_REPO" build


### PR DESCRIPTION
## Summary
- add `setup.sh` to fetch IntelliJ dependencies and run the build offline
- document the helper script in the README

## Testing
- `gradle help`
- `gradle build` *(fails: could not resolve IntelliJ dependency due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_687f6fb6a5f48326b9de4fdfead7fed7