### PR TITLE
Fix tile rendering width and height

### DIFF
--- a/src/com/lis/clash/map.kt
+++ b/src/com/lis/clash/map.kt
@@ -35,7 +35,7 @@ class MapPanel : JPanel() {
             val y = fromIndex(index).second
             val x = fromIndex(index).first
             g.color = (Color(colorByte, colorByte, colorByte))
-            g.fillRect(x * size, y * size, (x + 1) * size, (y + 1) * size)
+            g.fillRect(x * size, y * size, size, size)
         }
     }
 }


### PR DESCRIPTION
## Summary
- render tiles as size by size squares by using the tile size for fillRect width and height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca67917ec083268b7ec54d332e3d42