### PR TITLE
Add castle building flags and reporting script

### DIFF
--- a/src/com/lis/clash/objects/Castle.kt
+++ b/src/com/lis/clash/objects/Castle.kt
@@ -4,6 +4,14 @@ import com.lis.clash.ClashAggregateProperty
 import com.lis.clash.ClashSimpleProperty
 
 class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
+    companion object {
+        // Derived from clash95.c symbols: Building_BuildHospital/Barracks/Workshop/School.
+        const val BUILDING_HOSPITAL = 1
+        const val BUILDING_BARRACKS = 2
+        const val BUILDING_WORKSHOP = 4
+        const val BUILDING_SCHOOL = 8
+    }
+
     @ClashSimpleProperty(0, 1)
     var x: Byte by clashProperty(0)
 
@@ -52,6 +60,19 @@ class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
 
     @ClashSimpleProperty(425, 1)
     var walls: Byte by clashProperty(0)
+
+    fun hasBuilding(flag: Int): Boolean {
+        return (building.toInt() and flag) != 0
+    }
+
+    fun buildingNames(): List<String> {
+        val result = mutableListOf<String>()
+        if (hasBuilding(BUILDING_HOSPITAL)) result += "hospital"
+        if (hasBuilding(BUILDING_BARRACKS)) result += "barracks"
+        if (hasBuilding(BUILDING_WORKSHOP)) result += "workshop"
+        if (hasBuilding(BUILDING_SCHOOL)) result += "school"
+        return result
+    }
 
     override fun isValid(): Boolean {
         return type.toInt() != -1

--- a/src/com/lis/clash/scripts.kt
+++ b/src/com/lis/clash/scripts.kt
@@ -52,6 +52,22 @@ object Scripts {
         return "Save data exported to \"${outputFile.absolutePath}\""
     }
 
+    @ClashScript
+    fun listCastleBuildings(save: Save): String {
+        if (save.castles.isEmpty()) {
+            return "No castles found"
+        }
+
+        return save.castles.joinToString("\n") { castle ->
+            val buildings = castle.buildingNames().ifEmpty { listOf("none") }
+            val x = castle.x.toInt() and 0xFF
+            val y = castle.y.toInt() and 0xFF
+            val owner = castle.player.toInt() and 0xFF
+            val wallLevel = castle.walls.toInt() and 0xFF
+            "Castle(${x},${y}) owner=${owner} walls=${wallLevel} buildings=${buildings.joinToString(",")}"
+        }
+    }
+
     private fun writeSaveData(save: Save): File {
         val saveMap = save.toStructuredMap()
         val json = saveMap.toJsonString()


### PR DESCRIPTION
### Motivation

- Encode reverse-engineered castle building bitmask semantics discovered in `clash95.c` so the editor can decode which buildings a castle has and expose that data to scripts.

### Description

- Added building flag constants to `Castle` as `BUILDING_HOSPITAL`, `BUILDING_BARRACKS`, `BUILDING_WORKSHOP`, and `BUILDING_SCHOOL` in `src/com/lis/clash/objects/Castle.kt`.
- Added helper methods `hasBuilding(flag: Int)` and `buildingNames()` to `Castle` to decode the `building` bitmask and return human-readable names.
- Added a new script `listCastleBuildings(save: Save)` to `src/com/lis/clash/scripts.kt` that reports each castle's coordinates, owner, wall level, and decoded building list for use from the editor's Scripts UI.

### Testing

- Ran `./gradlew test` (initial attempt failed due to `gradlew` not being executable in the environment). 
- Ran `chmod +x gradlew && ./gradlew test`, which started the Gradle build but ultimately failed during automated dependency resolution with a remote HTTP 403 when fetching IntelliJ IDEA artifacts (`ideaIC-2023.1.pom`), so the test task did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ef6d5bf088326bc74a1028f6fd51c)