### PR TITLE
Use clash-disassembly data to improve save parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Project exclude paths
 /out
 .gradle/
+.gradle-home/
 build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,23 @@ intellij {
 
 sourceSets {
     main {
-        java.srcDir("src")
-        kotlin.srcDir("src")
-        resources.srcDir("src")
+        java {
+            srcDir("src")
+            exclude("test/**")
+        }
+        kotlin {
+            srcDir("src")
+            exclude("test/**")
+        }
+        resources {
+            srcDir("src")
+            exclude("test/**")
+        }
+    }
+
+    test {
+        java.srcDir("src/test/kotlin")
+        kotlin.srcDir("src/test/kotlin")
     }
 }
 

--- a/docs/reverse-engineering/clash95-overview.md
+++ b/docs/reverse-engineering/clash95-overview.md
@@ -11,7 +11,7 @@ This project currently targets the binary save file layout represented by `Save`
 ## Current high-confidence anchors
 - Save header `name` at bytes `0..15` (**High**).
 - `tiles` block starts at offset `16`, `10000` entries, `14` bytes each (**High**).
-- `players` block starts at offset `140044`, `5` entries, `1423` bytes each (**High**).
+- `players` block starts at offset `140040`, `5` entries, `1423` bytes each (**High**).
 - `armies` block starts at offset `147190`, `500` entries, `725` bytes each (**High**).
 - `castles` block starts at offset `509690`, `10` entries, `467` bytes each (**High**).
 
@@ -21,8 +21,11 @@ This project currently targets the binary save file layout represented by `Save`
 - barracks
 - workshop
 - school
+- smiths
 
-These are represented as bit flags in `Castle.building` and exposed read-only via helper methods (`hasBuilding`, `buildingNames`).
+These are represented as bit flags in `Castle.castleAddonFlags` and exposed via helper methods (`hasBuilding`, `buildingNames`).
+
+The current code also treats recovered multi-byte integers as little-endian and preserves unrelated bits for masked fields such as `Player.techLevel`, `Castle.peasantCount`, `Castle.plagueState`, `Castle.taxRate`, and `Castle.techLevelBits`.
 
 ## Boundaries
 This consolidation pass intentionally does **not** infer additional semantics for unknown bytes inside each fixed-size record. Unknown bytes remain preserved.

--- a/docs/reverse-engineering/final-status.md
+++ b/docs/reverse-engineering/final-status.md
@@ -2,26 +2,37 @@
 
 ## Confidently supported now
 - Fixed top-level section layout (`Save` name, tiles, players, armies, castles) with stable offsets and sizes.
+- Corrected player block base offset to `140040` and expanded `Player` parsing to include activation, camera, controller, religion, tech, battle-activity, and visibility state.
 - Nested object extraction for `Tile`, `Player`, `Army`, `Unit`, `Castle`.
-- Castle building bit flags exposed as: hospital, barracks, workshop, school.
+- Replaced the old guessed `Unit` runtime fields with recovered `typeId`, `ownerPlayerIndex`, `currentActionPoints`, `currentHealthPercent`, `fatigue`, `morale`, `stanceBits`, and `stateFlags`.
+- Expanded `Castle` parsing to include add-on ids, construction lock, wall strength, upgrade timer, masked peasant/tax/plague fields, stored money, tech bits, and fact id.
+- Castle building bit flags exposed as: hospital, barracks, workshop, school, smiths.
+- Fixed-width integer fields now round-trip as little-endian values, and masked bitfields preserve unrelated bits.
+- Save exports now include recovered unit roster names and sprite folders from `clash-disassembly`.
 - Conservative field-window serialization for known fields.
 
 ## Still uncertain / partial
 - Multiple per-structure bytes remain unknown/reserved.
-- Several exposed fields remain medium or low confidence (`type3`, `type4`, `dir`, `appearance`, `canBuild`, `shout`).
+- Several exposed fields remain medium or low confidence (`type3`, `type4`, `dir`, `appearance`, `stanceBits`, `stateFlags`).
 - No verified checksum/integrity algorithm is implemented.
 
 ## What this consolidation pass cleaned up
-- Added a unified reverse-engineering doc set under `docs/reverse-engineering/`.
-- Standardized confidence labeling and terminology across docs.
-- Corrected canonical castle field name to `happiness` while preserving deprecated alias `hapiness`.
-- Hardened fixed-length field writes to preserve trailing unknown bytes.
-- Added targeted regression tests for preservation and castle building flag decoding.
+- Promoted multiple player, unit, and castle fields from guessed names to recovered names backed by `clash-disassembly`.
+- Removed transitional deprecated accessors so the code, UI column names, and docs use one canonical schema.
+- Hardened scalar serialization for little-endian integers and masked fields.
+- Added targeted regression tests for the recovered player offset, castle money encoding, masked tax preservation, and castle building flag decoding.
 
 ## Files changed in this pass
 - `build.gradle.kts`
+- `src/com/lis/clash/converters.kt`
 - `src/com/lis/clash/objects/ClashObject.kt`
+- `src/com/lis/clash/objects/Player.kt`
+- `src/com/lis/clash/objects/Save.kt`
+- `src/com/lis/clash/objects/Unit.kt`
 - `src/com/lis/clash/objects/Castle.kt`
+- `src/com/lis/clash/parser.kt`
+- `src/com/lis/clash/scripts.kt`
+- `src/com/lis/clash/types.kt`
 - `src/test/kotlin/com/lis/clash/SaveConsolidationTest.kt`
 - `docs/reverse-engineering/clash95-overview.md`
 - `docs/reverse-engineering/save-format.md`
@@ -35,7 +46,7 @@
 - Broad schema refactors.
 - New semantics for unknown bytes.
 - Checksum algorithm implementation without strong evidence.
-- UI redesign for confidence-aware edit gating.
+- UI redesign for confidence-aware edit gating beyond the improved field names.
 
 ## Recommended next steps
 1. Establish a checksum/integrity evidence track (if present in original game).

--- a/docs/reverse-engineering/invariants.md
+++ b/docs/reverse-engineering/invariants.md
@@ -5,13 +5,14 @@
 - A section entry is materialized into an object only while `isValid()` remains true for that entry type.
 
 ## Entry validity rules in current implementation
-- `Unit` is valid when `type != -1`.
+- `Unit` is valid when `typeId != 0xFF`.
 - `Army` is valid when it has at least one valid unit.
 - `Castle` is valid when `type != -1`.
 - `Tile` and `Player` currently have no additional validity guard beyond fixed slicing.
 
 ## Serialization invariants
 - Editing a known field updates only that field's byte window.
+- Masked numeric edits preserve unrelated bits in the same byte window.
 - If new field data is shorter than fixed field length, untouched tail bytes are preserved.
 - If new field data is longer than fixed field length, data is truncated to field length.
 - Non-edited regions are preserved byte-for-byte.

--- a/docs/reverse-engineering/safety-and-integrity.md
+++ b/docs/reverse-engineering/safety-and-integrity.md
@@ -8,12 +8,13 @@
 ## Consolidation hardening applied
 - Fixed-length simple field writes now preserve trailing bytes when new value is shorter.
 - Overlong values are truncated to field size instead of spilling.
-- Legacy misspelling `hapiness` is retained as a deprecated alias while canonical name is `happiness`.
+- Fixed-width integer fields now serialize as little-endian values.
+- Masked numeric fields preserve unrelated bits in the same byte window.
 
 ## Remaining risks
 - Byte table permits raw editing and can corrupt data if misused.
 - No end-to-end checksum/integrity algorithm is currently implemented (none confidently identified in current codebase).
-- Some field converters (especially generic integer handling) are not yet backed by strong format proof.
+- Low-confidence fields such as `Tile.type3`, `Tile.type4`, `Army.dir`, and `Castle.appearance` remain only partially understood.
 
 ## Conservative usage guidance
 - Prefer structure-table edits over raw byte-table edits.

--- a/docs/reverse-engineering/save-format.md
+++ b/docs/reverse-engineering/save-format.md
@@ -5,7 +5,7 @@
 |---|---:|---:|---:|---|
 | Save name | 0 | 1 | 16 | High |
 | Tiles | 16 | 10000 | 14 | High |
-| Players | 140044 | 5 | 1423 | High |
+| Players | 140040 | 5 | 1423 | High |
 | Armies | 147190 | 500 | 725 | High |
 | Castles | 509690 | 10 | 467 | High |
 
@@ -24,8 +24,18 @@ Other bytes are currently unknown/reserved (Low).
 
 ### Player (1423 bytes)
 Known fields:
-- `name` at +0, length 10 (High)
-- `explored` at +53, length 1300 (Medium: behavior known, exact semantics partially known)
+- `isActive` at +0, length 4 (High)
+- `displayName` at +4, length 11 (High)
+- `cameraLeft` at +15, length 4 (High)
+- `cameraTop` at +19, length 4 (High)
+- `minimapVisibleFlag` at +23, length 4 (High)
+- `controllerMode` at +27, length 4 (High)
+- `religionFlag` at +39, length 4 (High)
+- `techLevel` at +47, low 3 bits (High)
+- `lastReportedTechLevel` at +48, low 3 bits (High)
+- `battleActionTakenFlag` at +49, length 4 (High)
+- `consecutiveIdleBattleTurns` at +53, length 4 (High)
+- `revealedTilesBitset` at +57, length 1300 (High)
 
 Other bytes unknown/reserved (Low).
 
@@ -41,12 +51,14 @@ Remaining bytes unknown/reserved (Low).
 
 ### Unit (31 bytes)
 Known fields:
-- `type` +0 (High for occupancy marker)
-- `move` +8 (Medium)
-- `health` +9 (Medium)
-- `shout` +10 (Low/Medium)
-- `morale` +11 (Medium)
-- `exp` +12 (Medium)
+- `typeId` +0 (High for occupancy marker)
+- `ownerPlayerIndex` +2 (High)
+- `currentActionPoints` +8 (High)
+- `currentHealthPercent` +9 (High)
+- `fatigue` +10 (High)
+- `morale` +11 (High)
+- `stanceBits` +12 (Medium/High)
+- `stateFlags` +13 (Medium/High)
 
 Remaining bytes unknown/reserved (Low).
 
@@ -59,13 +71,18 @@ Known fields:
 - `type` +4 (High for occupancy marker)
 - `name` +5, length 10 (High)
 - `units` +18, count 12, entry size 31 (High for layout)
-- `unitsToBuild` +402, length 12 (Medium)
-- `building` +416 (Medium/High for bit-mask use)
-- `canBuild` +420 (Low/Medium)
-- `walls` +425 (Medium)
-- `peasants` +430 (Medium)
-- `happiness` +434 (Medium)
-- `tax` +436 (Medium)
-- `gold` +438 (Medium)
+- `addonTypeIds` +402, length 12 (High)
+- `selectedAddonSlotIndex` +414 (High)
+- `castleAddonFlags` +416 (High)
+- `constructionLockFlags` +420 (High)
+- `wallStrength` +421 (High)
+- `upgradeTimerTurns` +429 (High)
+- `peasantCount` +430, low 12 bits (High)
+- `satisfaction` +434 (High)
+- `plagueState` +435, low 3 bits (High)
+- `taxRate` +436, low 6 bits (High)
+- `storedMoney` +438, length 4 (High)
+- `techLevelBits` +444, low 3 bits (High)
+- `castleFactId` +463, length 4 (High)
 
 Remaining bytes unknown/reserved (Low).

--- a/docs/reverse-engineering/unknown-fields.md
+++ b/docs/reverse-engineering/unknown-fields.md
@@ -10,9 +10,7 @@ This document tracks fields that are intentionally kept neutral.
 ## Low-confidence names still exposed in code
 - `Tile.type3`, `Tile.type4`
 - `Castle.appearance`
-- `Castle.canBuild`
 - `Army.dir`
-- `Unit.shout`
 
 These names are historical placeholders and do not imply complete semantic certainty.
 

--- a/src/com/lis/clash/converters.kt
+++ b/src/com/lis/clash/converters.kt
@@ -1,7 +1,5 @@
 package com.lis.clash
 
-import java.math.BigInteger
-
 val converters = mapOf(
     Byte::class to ByteConverter::class.objectInstance,
     String::class to StringConverter::class.objectInstance,
@@ -13,8 +11,23 @@ interface Converter {
     fun toString(t: Any): String
     fun fromString(s: String): Any
 
-    fun toBytes(t: Any): List<Byte>
-    fun fromBytes(s: List<Byte>): Any
+    fun toBytes(t: Any, length: Int): List<Byte>
+    fun fromBytes(s: List<Byte>, length: Int = s.size): Any
+}
+
+internal fun readLittleEndianInt(bytes: List<Byte>): Int {
+    var result = 0
+    bytes.forEachIndexed { index, byte ->
+        result = result or ((byte.toInt() and 0xFF) shl (index * 8))
+    }
+    return result
+}
+
+internal fun writeLittleEndianInt(value: Int, length: Int): List<Byte> {
+    require(length in 1..4) { "Unsupported integer length: $length" }
+    return List(length) { index ->
+        ((value ushr (index * 8)) and 0xFF).toByte()
+    }
 }
 
 object ByteConverter : Converter {
@@ -26,11 +39,11 @@ object ByteConverter : Converter {
         return s.toByte()
     }
 
-    override fun toBytes(t: Any): List<Byte> {
+    override fun toBytes(t: Any, length: Int): List<Byte> {
         return listOf(t as Byte)
     }
 
-    override fun fromBytes(s: List<Byte>): Any {
+    override fun fromBytes(s: List<Byte>, length: Int): Any {
         return s.first()
     }
 }
@@ -44,12 +57,12 @@ object ListConverter : Converter {
         return s.subSequence(1, s.length - 2).split(",").map { it.toByte() }
     }
 
-    override fun toBytes(t: Any): List<Byte> {
+    override fun toBytes(t: Any, length: Int): List<Byte> {
         @Suppress("UNCHECKED_CAST")
         return t as List<Byte>
     }
 
-    override fun fromBytes(s: List<Byte>): Any {
+    override fun fromBytes(s: List<Byte>, length: Int): Any {
         return s
     }
 }
@@ -63,11 +76,11 @@ object StringConverter : Converter {
         return s
     }
 
-    override fun toBytes(t: Any): List<Byte> {
+    override fun toBytes(t: Any, length: Int): List<Byte> {
         return (t as String).toByteArray().toList()
     }
 
-    override fun fromBytes(s: List<Byte>): Any {
+    override fun fromBytes(s: List<Byte>, length: Int): Any {
         return String(s.toByteArray())
     }
 
@@ -83,17 +96,12 @@ object IntConverter : Converter {
         return s.toInt()
     }
 
-    override fun toBytes(t: Any): List<Byte> {
-        var retVal = (t as Int).toBigInteger().toByteArray().asList()
-        if (retVal.size == 1) {
-            retVal = retVal + listOf(0.toByte())
-        }
-        return retVal
+    override fun toBytes(t: Any, length: Int): List<Byte> {
+        return writeLittleEndianInt(t as Int, length)
     }
 
-    override fun fromBytes(s: List<Byte>): Any {
-        val bigInteger = BigInteger(s.toByteArray())
-        return bigInteger.toInt()
+    override fun fromBytes(s: List<Byte>, length: Int): Any {
+        return readLittleEndianInt(s.take(length))
     }
 
 }

--- a/src/com/lis/clash/objects/Castle.kt
+++ b/src/com/lis/clash/objects/Castle.kt
@@ -1,15 +1,17 @@
 package com.lis.clash.objects
 
 import com.lis.clash.ClashAggregateProperty
+import com.lis.clash.ClashMaskedProperty
 import com.lis.clash.ClashSimpleProperty
 
 class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     companion object {
-        // Derived from clash95.c symbols: Building_BuildHospital/Barracks/Workshop/School.
+        // Derived from clash95.c / clash-disassembly building facts.
         const val BUILDING_HOSPITAL = 1
         const val BUILDING_BARRACKS = 2
         const val BUILDING_WORKSHOP = 4
         const val BUILDING_SCHOOL = 8
+        const val BUILDING_SMITHS = 16
     }
 
     @ClashSimpleProperty(0, 1)
@@ -34,42 +36,46 @@ class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     var units: List<Unit> by clashProperty(emptyList())
 
     @ClashSimpleProperty(402, 12)
-    var unitsToBuild: List<Byte> by clashProperty(emptyList())
+    var addonTypeIds: List<Byte> by clashProperty(emptyList())
 
-    @ClashSimpleProperty(430, 1)
-    var peasants: Byte by clashProperty(0)
+    @ClashSimpleProperty(414, 1)
+    var selectedAddonSlotIndex: Int by clashProperty(0)
 
-    @ClashSimpleProperty(434, 1)
-    var happiness: Byte by clashProperty(0)
-
-    @Deprecated("Use happiness", ReplaceWith("happiness"))
-    var hapiness: Byte
-        get() = happiness
-        set(value) {
-            happiness = value
-        }
-
-    @ClashSimpleProperty(438, 1)
-    var gold: Byte by clashProperty(0)
-
-    //1 hospital
-    //2 barrracks
-    //4 workshop
-    //8 school
     @ClashSimpleProperty(416, 1)
-    var building: Byte by clashProperty(0)
+    var castleAddonFlags: Int by clashProperty(0)
 
     @ClashSimpleProperty(420, 1)
-    var canBuild: Byte by clashProperty(0)
+    var constructionLockFlags: Int by clashProperty(0)
 
-    @ClashSimpleProperty(436, 1)
-    var tax: Byte by clashProperty(0)
+    @ClashSimpleProperty(421, 1)
+    var wallStrength: Int by clashProperty(0)
 
-    @ClashSimpleProperty(425, 1)
-    var walls: Byte by clashProperty(0)
+    @ClashSimpleProperty(429, 1)
+    var upgradeTimerTurns: Int by clashProperty(0)
+
+    @ClashMaskedProperty(430, 2, 0x0FFF)
+    var peasantCount: Int by clashProperty(0)
+
+    @ClashSimpleProperty(434, 1)
+    var satisfaction: Int by clashProperty(0)
+
+    @ClashMaskedProperty(435, 1, 0x07)
+    var plagueState: Int by clashProperty(0)
+
+    @ClashMaskedProperty(436, 1, 0x3F)
+    var taxRate: Int by clashProperty(0)
+
+    @ClashSimpleProperty(438, 4)
+    var storedMoney: Int by clashProperty(0)
+
+    @ClashMaskedProperty(444, 1, 0x07)
+    var techLevelBits: Int by clashProperty(0)
+
+    @ClashSimpleProperty(463, 4)
+    var castleFactId: Int by clashProperty(0)
 
     fun hasBuilding(flag: Int): Boolean {
-        return (building.toInt() and flag) != 0
+        return (castleAddonFlags and flag) != 0
     }
 
     fun buildingNames(): List<String> {
@@ -78,6 +84,7 @@ class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
         if (hasBuilding(BUILDING_BARRACKS)) result += "barracks"
         if (hasBuilding(BUILDING_WORKSHOP)) result += "workshop"
         if (hasBuilding(BUILDING_SCHOOL)) result += "school"
+        if (hasBuilding(BUILDING_SMITHS)) result += "smiths"
         return result
     }
 

--- a/src/com/lis/clash/objects/ClashObject.kt
+++ b/src/com/lis/clash/objects/ClashObject.kt
@@ -25,7 +25,8 @@ open class ClashObject(val parent: ClashObject?, val index: Int) {
         return Delegates.observable(initialValue, { property, oldValue, newValue ->
             if (oldValue != newValue) {
                 getClassDescriptor(this::class).getSimpleProperty(property.name)?.let {
-                    val toBytes = it.getConverter().toBytes(newValue!!)
+                    val currentBytes = bytes.slice(it.index() until (it.index() + it.length()))
+                    val toBytes = it.toBytes(newValue!!, currentBytes)
                     val boundedBytes = if (toBytes.size > it.length()) {
                         toBytes.take(it.length())
                     } else {

--- a/src/com/lis/clash/objects/Player.kt
+++ b/src/com/lis/clash/objects/Player.kt
@@ -1,11 +1,42 @@
 package com.lis.clash.objects
 
+import com.lis.clash.ClashMaskedProperty
 import com.lis.clash.ClashSimpleProperty
 
 class Player(parent: ClashObject, index: Int) : ClashObject(parent, index) {
-    @ClashSimpleProperty(0, 10)
-    var name: String by clashProperty("")
+    @ClashSimpleProperty(0, 4)
+    var isActive: Int by clashProperty(0)
 
-    @ClashSimpleProperty(53, 1300)
-    var explored: List<Byte> by clashProperty(emptyList())
+    @ClashSimpleProperty(4, 11)
+    var displayName: String by clashProperty("")
+
+    @ClashSimpleProperty(15, 4)
+    var cameraLeft: Int by clashProperty(0)
+
+    @ClashSimpleProperty(19, 4)
+    var cameraTop: Int by clashProperty(0)
+
+    @ClashSimpleProperty(23, 4)
+    var minimapVisibleFlag: Int by clashProperty(0)
+
+    @ClashSimpleProperty(27, 4)
+    var controllerMode: Int by clashProperty(0)
+
+    @ClashSimpleProperty(39, 4)
+    var religionFlag: Int by clashProperty(0)
+
+    @ClashMaskedProperty(47, 1, 0x07)
+    var techLevel: Int by clashProperty(0)
+
+    @ClashMaskedProperty(48, 1, 0x07)
+    var lastReportedTechLevel: Int by clashProperty(0)
+
+    @ClashSimpleProperty(49, 4)
+    var battleActionTakenFlag: Int by clashProperty(0)
+
+    @ClashSimpleProperty(53, 4)
+    var consecutiveIdleBattleTurns: Int by clashProperty(0)
+
+    @ClashSimpleProperty(57, 1300)
+    var revealedTilesBitset: List<Byte> by clashProperty(emptyList())
 }

--- a/src/com/lis/clash/objects/Save.kt
+++ b/src/com/lis/clash/objects/Save.kt
@@ -2,7 +2,6 @@ package com.lis.clash.objects
 
 import com.lis.clash.ClashAggregateProperty
 import com.lis.clash.ClashSimpleProperty
-import com.lis.clash.StringConverter
 
 class Save : ClashObject(null, 0) {
     @ClashSimpleProperty(0, 16)
@@ -14,7 +13,7 @@ class Save : ClashObject(null, 0) {
     @ClashAggregateProperty(147190, 500, 725, Army::class)
     var armies: List<Army> by clashProperty(emptyList())
 
-    @ClashAggregateProperty(140044, 5, 1423, Player::class)
+    @ClashAggregateProperty(140040, 5, 1423, Player::class)
     var players: List<Player> by clashProperty(emptyList())
 
     @ClashAggregateProperty(509690, 10, 467, Castle::class)

--- a/src/com/lis/clash/objects/Unit.kt
+++ b/src/com/lis/clash/objects/Unit.kt
@@ -1,29 +1,34 @@
 package com.lis.clash.objects
 
-import com.lis.clash.ByteConverter
 import com.lis.clash.ClashSimpleProperty
 
 class Unit(parent: ClashObject, index: Int) : ClashObject(parent, index) {
-    @ClashSimpleProperty(12, 1)
-    var exp: Byte by clashProperty(0)
+    @ClashSimpleProperty(0, 1)
+    var typeId: Int by clashProperty(0)
 
-    @ClashSimpleProperty(11, 1)
-    var morale: Byte by clashProperty(0)
-
-    @ClashSimpleProperty(10, 1)
-    var shout: Byte by clashProperty(0)
-
-    @ClashSimpleProperty(9, 1)
-    var health: Byte by clashProperty(0)
+    @ClashSimpleProperty(2, 1)
+    var ownerPlayerIndex: Int by clashProperty(0)
 
     @ClashSimpleProperty(8, 1)
-    var move: Byte by clashProperty(0)
+    var currentActionPoints: Int by clashProperty(0)
 
-    @ClashSimpleProperty(0, 1)
-    var type: Byte by clashProperty(0)
+    @ClashSimpleProperty(9, 1)
+    var currentHealthPercent: Int by clashProperty(0)
+
+    @ClashSimpleProperty(10, 1)
+    var fatigue: Int by clashProperty(0)
+
+    @ClashSimpleProperty(11, 1)
+    var morale: Int by clashProperty(0)
+
+    @ClashSimpleProperty(12, 1)
+    var stanceBits: Int by clashProperty(0)
+
+    @ClashSimpleProperty(13, 1)
+    var stateFlags: Int by clashProperty(0)
 
     override fun isValid(): Boolean {
-        return type.toInt() != -1
+        return typeId != 0xFF
     }
 
 }

--- a/src/com/lis/clash/parser.kt
+++ b/src/com/lis/clash/parser.kt
@@ -12,6 +12,13 @@ import kotlin.reflect.jvm.jvmErasure
 
 annotation class ClashSimpleProperty(val index: Int, val length: Int)
 
+annotation class ClashMaskedProperty(
+    val index: Int,
+    val length: Int,
+    val mask: Int,
+    val shift: Int = 0
+)
+
 annotation class ClashAggregateProperty(
     val index: Int,
     val count: Int,
@@ -36,11 +43,11 @@ abstract class ClashPropertyDescriptor(val _property: KMutableProperty<ClashObje
     }
 
     fun setString(_object: ClashObject, value: String) {
-        _property.setter.call(_object, getConverter().fromString(value))
+        _property.setter.call(_object, fromString(value))
     }
 
     fun setBytes(_object: ClashObject, value: List<Byte>) {
-        _property.setter.call(_object, getConverter().fromBytes(value))
+        _property.setter.call(_object, fromBytes(value))
     }
 
     fun set(_object: ClashObject, value: Any) {
@@ -51,6 +58,18 @@ abstract class ClashPropertyDescriptor(val _property: KMutableProperty<ClashObje
 
     fun getName(): String {
         return _property.name
+    }
+
+    open fun fromString(value: String): Any {
+        return getConverter().fromString(value)
+    }
+
+    open fun fromBytes(value: List<Byte>): Any {
+        return getConverter().fromBytes(value, length())
+    }
+
+    open fun toBytes(value: Any, currentBytes: List<Byte>): List<Byte> {
+        return getConverter().toBytes(value, length())
     }
 }
 
@@ -70,6 +89,43 @@ class SimplePropertyDescriptor(_property: KMutableProperty<ClashObject>) : Clash
 
     override fun getConverter(): Converter {
         return converters[_property.getter.returnType.jvmErasure]!!
+    }
+}
+
+class MaskedPropertyDescriptor(_property: KMutableProperty<ClashObject>) : ClashPropertyDescriptor(_property) {
+    private val annotation: ClashMaskedProperty = _property.findAnnotation()!!
+
+    override fun index(): Int {
+        return annotation.index
+    }
+
+    override fun length(): Int {
+        return annotation.length
+    }
+
+    override fun isSimple(): Boolean {
+        return true
+    }
+
+    override fun getConverter(): Converter {
+        return IntConverter
+    }
+
+    override fun fromString(value: String): Any {
+        return value.toInt()
+    }
+
+    override fun fromBytes(value: List<Byte>): Any {
+        val rawValue = readLittleEndianInt(value)
+        return (rawValue ushr annotation.shift) and annotation.mask
+    }
+
+    override fun toBytes(value: Any, currentBytes: List<Byte>): List<Byte> {
+        val currentValue = readLittleEndianInt(currentBytes)
+        val shiftedMask = annotation.mask shl annotation.shift
+        val maskedValue = (((value as Int) and annotation.mask) shl annotation.shift)
+        val updatedValue = (currentValue and shiftedMask.inv()) or maskedValue
+        return writeLittleEndianInt(updatedValue, length())
     }
 }
 
@@ -107,8 +163,8 @@ class AggregatePropertyDescriptor(_property: KMutableProperty<ClashObject>) : Cl
 
 class ClassDescriptor(val properties: List<ClashPropertyDescriptor>) {
 
-    fun getSimpleProperties(): List<SimplePropertyDescriptor> {
-        return properties.filter { it.isSimple() }.map { it as SimplePropertyDescriptor }
+    fun getSimpleProperties(): List<ClashPropertyDescriptor> {
+        return properties.filter { it.isSimple() }
     }
 
     fun getAggregateProperties(): List<AggregatePropertyDescriptor> {
@@ -129,7 +185,7 @@ class ClassDescriptor(val properties: List<ClashPropertyDescriptor>) {
         return getOrderedSimpleProperties()[col]
     }
 
-    fun getSimpleProperty(name: String): SimplePropertyDescriptor? {
+    fun getSimpleProperty(name: String): ClashPropertyDescriptor? {
         return getSimpleProperties().find { it.getName() == name }
     }
 
@@ -161,6 +217,8 @@ object AnnotationParser {
     private fun parseProperty(property: KMutableProperty<ClashObject>): ClashPropertyDescriptor? {
         if (property.hasAnnotation<ClashSimpleProperty>()) {
             return SimplePropertyDescriptor(property)
+        } else if (property.hasAnnotation<ClashMaskedProperty>()) {
+            return MaskedPropertyDescriptor(property)
         } else if (property.hasAnnotation<ClashAggregateProperty>()) {
             return AggregatePropertyDescriptor(property)
         }

--- a/src/com/lis/clash/scripts.kt
+++ b/src/com/lis/clash/scripts.kt
@@ -1,8 +1,10 @@
 package com.lis.clash
 
 import com.lis.clash.objects.ClashObject
+import com.lis.clash.objects.Castle
 import com.lis.clash.objects.Save
 import com.lis.clash.objects.Tile
+import com.lis.clash.objects.Unit
 import java.io.File
 
 annotation class ClashScript
@@ -36,7 +38,7 @@ object Scripts {
     @ClashScript
     fun exploreAll(save: Save) {
         return save.players.forEach {
-            it.explored = List(1300) { Integer.valueOf(255).toByte() }
+            it.revealedTilesBitset = List(1300) { Integer.valueOf(255).toByte() }
         }
     }
 
@@ -63,7 +65,7 @@ object Scripts {
             val x = castle.x.toInt() and 0xFF
             val y = castle.y.toInt() and 0xFF
             val owner = castle.player.toInt() and 0xFF
-            val wallLevel = castle.walls.toInt() and 0xFF
+            val wallLevel = castle.wallStrength and 0xFF
             "Castle(${x},${y}) owner=${owner} walls=${wallLevel} buildings=${buildings.joinToString(",")}"
         }
     }
@@ -102,6 +104,18 @@ object Scripts {
             result["mapY"] = listIndex % 100
             val tileName = TILE.values().firstOrNull { it.matches(this) }?.name
             result["tileName"] = tileName
+        }
+
+        if (this is Unit) {
+            UnitTypes.metadata(typeId)?.let { metadata ->
+                result["unitTypeName"] = metadata.displayName
+                result["unitLocalizedNames"] = metadata.localizedNames
+                result["unitSpriteFolder"] = metadata.folder
+            }
+        }
+
+        if (this is Castle) {
+            result["buildingNames"] = buildingNames()
         }
 
         return result

--- a/src/com/lis/clash/types.kt
+++ b/src/com/lis/clash/types.kt
@@ -2,8 +2,57 @@ package com.lis.clash
 
 import com.lis.clash.objects.Tile
 
-enum class UNIT {
+data class UnitTypeMetadata(
+    val id: Int,
+    val localizedNames: String,
+    val folder: String
+) {
+    val displayName: String
+        get() = localizedNames.split(" / ").getOrNull(1) ?: localizedNames.split(" / ").first()
+}
 
+object UnitTypes {
+    val all = listOf(
+        UnitTypeMetadata(0, "Posp. ruszenie / Peasant / Bauern", "peon"),
+        UnitTypeMetadata(1, "Lekka piechota / Light infantry", "infl"),
+        UnitTypeMetadata(2, "Ciężka piechota / Heavy infantry", "infh"),
+        UnitTypeMetadata(3, "Pikinier / Pikeman", "sprl"),
+        UnitTypeMetadata(4, "Halabardnik / Heavy spearman", "sprh"),
+        UnitTypeMetadata(5, "Lekka jazda / Light cavalry", "cavl"),
+        UnitTypeMetadata(6, "Ciężka jazda / Heavy cavalry", "cavh"),
+        UnitTypeMetadata(7, "Rycerstwo / Knights", "ryc"),
+        UnitTypeMetadata(8, "Dragon / Dragon cavalry", "drag"),
+        UnitTypeMetadata(9, "Łucznik / Archer", "arch"),
+        UnitTypeMetadata(10, "Kusznik / Crossbower", "kusza"),
+        UnitTypeMetadata(11, "Muszkieter / Musketeer", "muszk"),
+        UnitTypeMetadata(12, "Katapulta / Catapult", "katap"),
+        UnitTypeMetadata(13, "Taran / Taran / Rammbock", "taran"),
+        UnitTypeMetadata(14, "Armata / Cannon / Kanonen", "armat"),
+        UnitTypeMetadata(15, "Leśnik / Forester", "lesn"),
+        UnitTypeMetadata(16, "Góral / Highlander", "goral"),
+        UnitTypeMetadata(17, "Budowniczy / Builder", "budow"),
+        UnitTypeMetadata(18, "Czerw / Worm", "worm"),
+        UnitTypeMetadata(19, "Słoń / Elephant", "slon"),
+        UnitTypeMetadata(20, "Cyklop / Cyclop", "cykl"),
+        UnitTypeMetadata(21, "Troll", "trol"),
+        UnitTypeMetadata(22, "Skorpion / Scorpion", "scorp"),
+        UnitTypeMetadata(23, "Szkielet / Skeleton", "szk"),
+        UnitTypeMetadata(24, "Mag / Wizard", "mag"),
+        UnitTypeMetadata(25, "Duch / Ghost", "duch"),
+        UnitTypeMetadata(26, "Orzeł / Eagle", "orzel"),
+        UnitTypeMetadata(27, "Pegaz / Pegasus", "pegaz"),
+        UnitTypeMetadata(28, "Skrzydlak / Winger", "skrz"),
+        UnitTypeMetadata(29, "Ważka / Fly / Riesenlibelle", "wazka"),
+        UnitTypeMetadata(30, "Smok / Dragon / Drachen", "smok"),
+        UnitTypeMetadata(31, "Złoto / Gold", "gold"),
+        UnitTypeMetadata(32, "Chłopi / Peasants", "peas"),
+        UnitTypeMetadata(33, "Dowódca / Tactician / Soldat", "specm"),
+        UnitTypeMetadata(34, "Dowódca / Tactician / Soldat", "speck")
+    )
+
+    private val byId = all.associateBy(UnitTypeMetadata::id)
+
+    fun metadata(typeId: Int): UnitTypeMetadata? = byId[typeId]
 }
 
 enum class TILE(val type1: Byte, val type2: Byte) {

--- a/src/test/kotlin/com/lis/clash/SaveConsolidationTest.kt
+++ b/src/test/kotlin/com/lis/clash/SaveConsolidationTest.kt
@@ -9,6 +9,11 @@ import kotlin.test.assertTrue
 class SaveConsolidationTest {
     private val saveSize = 514360
     private val firstCastleOffset = 509690
+    private val firstPlayerOffset = 140040
+
+    private fun blankParentSave(): Save {
+        return Save().withBytes<Save>(MutableList(saveSize) { 0.toByte() })
+    }
 
     @Test
     fun `editing fixed-length string preserves trailing bytes`() {
@@ -37,20 +42,69 @@ class SaveConsolidationTest {
         val untouchedIndex = firstCastleOffset + 300
         val before = save.bytes[untouchedIndex]
 
-        save.castles.first().happiness = 9
+        save.castles.first().satisfaction = 9
 
         assertEquals(before, save.bytes[untouchedIndex])
     }
 
     @Test
     fun `castle building flags decode consistently`() {
-        val castle = Castle(parent = Save(), index = 0)
+        val castle = Castle(parent = blankParentSave(), index = firstCastleOffset)
         castle.bytes = MutableList(467) { 0 }
-        castle.building = (Castle.BUILDING_HOSPITAL or Castle.BUILDING_SCHOOL).toByte()
+        castle.castleAddonFlags = Castle.BUILDING_HOSPITAL or Castle.BUILDING_SCHOOL
 
         val names = castle.buildingNames()
         assertEquals(listOf("hospital", "school"), names)
         assertTrue(castle.hasBuilding(Castle.BUILDING_HOSPITAL))
         assertTrue(castle.hasBuilding(Castle.BUILDING_SCHOOL))
+    }
+
+    @Test
+    fun `stored money uses little endian four byte layout`() {
+        val castle = Castle(parent = blankParentSave(), index = firstCastleOffset)
+        val bytes = MutableList(467) { 0.toByte() }
+        bytes[4] = 1
+        bytes[438] = 0x78.toByte()
+        bytes[439] = 0x56.toByte()
+        bytes[440] = 0x34.toByte()
+        bytes[441] = 0x12.toByte()
+        castle.bytes = bytes
+
+        assertEquals(0x12345678, castle.storedMoney)
+
+        castle.storedMoney = 0x01020304
+        assertEquals(0x04.toByte(), castle.bytes[438])
+        assertEquals(0x03.toByte(), castle.bytes[439])
+        assertEquals(0x02.toByte(), castle.bytes[440])
+        assertEquals(0x01.toByte(), castle.bytes[441])
+    }
+
+    @Test
+    fun `masked tax rate preserves unrelated high bits`() {
+        val castle = Castle(parent = blankParentSave(), index = firstCastleOffset)
+        val bytes = MutableList(467) { 0.toByte() }
+        bytes[4] = 1
+        bytes[436] = 0b11000000.toByte()
+        castle.bytes = bytes
+
+        castle.taxRate = 17
+
+        assertEquals(0b11010001.toByte(), castle.bytes[436])
+        assertEquals(17, castle.taxRate)
+    }
+
+    @Test
+    fun `players parse from recovered base offset`() {
+        val base = MutableList(saveSize) { 0.toByte() }
+        base[firstPlayerOffset] = 1
+        "Drebegen".encodeToByteArray().forEachIndexed { index, byte ->
+            base[firstPlayerOffset + 4 + index] = byte
+        }
+        base[firstCastleOffset + 4] = 1
+
+        val save = Save().withBytes<Save>(base)
+
+        assertEquals(1, save.players.first().isActive)
+        assertEquals("Drebegen\u0000\u0000\u0000", save.players.first().displayName)
     }
 }


### PR DESCRIPTION
## What changed
- corrected the player section base offset to `140040` and expanded parsed player runtime fields
- replaced older guessed `Unit` runtime fields with recovered slot fields from `clash-disassembly`
- expanded `Castle` parsing with recovered add-on, economy, tech, and masked bitfield data, including little-endian `storedMoney`
- added recovered unit roster metadata so save exports include readable unit names and sprite folders
- fixed Gradle source-set wiring so `src/test/kotlin` is compiled as test code instead of main code
- updated reverse-engineering docs to match the recovered schema

## Why it was changed
The save editor was still relying on several outdated or partial field guesses. `clash-disassembly` now contains stronger recovered structure data for player, unit-slot, and building records, so the editor can parse and edit more of the save file accurately and export more useful data.

## Validation performed
- ran `GRADLE_USER_HOME=/home/andrz/git/clash-save-editor/.gradle-home ./gradlew test`
- added regression coverage for the recovered player base offset, little-endian castle money encoding, masked tax-rate preservation, and castle add-on flag decoding

## Known limitations / follow-up work
- low-confidence fields such as `Tile.type3`, `Tile.type4`, `Army.dir`, and `Castle.appearance` remain only partially understood
- Gradle still reports pre-existing plugin configuration warnings about Java 9 vs IntelliJ 2023.1 and Kotlin stdlib handling
- no checksum/integrity algorithm has been identified or implemented yet