### PR TITLE
Expand recovered save schema and debugging UI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,12 +53,14 @@ tasks.withType<JavaCompile> {
 }
 
 val fatJar = tasks.register<Jar>("fatJar") {
-    dependsOn(tasks.named("classes"))
+    dependsOn(tasks.named("instrumentCode"))
+    dependsOn(tasks.named("processResources"))
     archiveClassifier.set("all")
     manifest {
         attributes["Main-Class"] = "com.lis.clash.ClashKt"
     }
-    from(sourceSets.main.get().output)
+    from(layout.buildDirectory.dir("instrumented/instrumentCode"))
+    from(layout.buildDirectory.dir("resources/main"))
     from({
         configurations.runtimeClasspath.get().filter { it.name.endsWith(".jar") }.map { zipTree(it) }
     })

--- a/docs/reverse-engineering/save-format.md
+++ b/docs/reverse-engineering/save-format.md
@@ -5,6 +5,7 @@
 |---|---:|---:|---:|---|
 | Save name | 0 | 1 | 16 | High |
 | Tiles | 16 | 10000 | 14 | High |
+| Shared world view state | 140000 | 1 | 7147 | High for listed fields |
 | Players | 140040 | 5 | 1423 | High |
 | Armies | 147190 | 500 | 725 | High |
 | Castles | 509690 | 10 | 467 | High |
@@ -15,12 +16,21 @@ Minimum represented file size: `514360` bytes.
 
 ### Tile (14 bytes)
 Known fields:
-- `type1` at +0 (Medium)
-- `type2` at +1 (Medium)
-- `type3` at +2 (Low)
-- `type4` at +3 (Low)
+- `terrainTileId` at +0, length 2 (High)
+- `overlayTileId` at +2, length 2 (High)
+- `roadOrBridgeTileId` at +4, length 2 (High)
 
 Other bytes are currently unknown/reserved (Low).
+
+### Shared world view state
+Known fields:
+- `mapWidthTiles` at +140000, length 4 (High)
+- `mapHeightTiles` at +140004, length 4 (High)
+- `mapViewLeft` at +140008, length 4 (High)
+- `mapViewTop` at +140012, length 4 (High)
+- `activeMissionIndex` at +140017, length 4 (High)
+- `turnOwnerPlayerIndex` at +147139, length 4 (High)
+- `viewedPlayerIndex` at +147143, length 4 (High)
 
 ### Player (1423 bytes)
 Known fields:
@@ -36,22 +46,28 @@ Known fields:
 - `battleActionTakenFlag` at +49, length 4 (High)
 - `consecutiveIdleBattleTurns` at +53, length 4 (High)
 - `revealedTilesBitset` at +57, length 1300 (High)
+- `prisonerTransferQueueRaw` at +1357, length 60 (High for layout)
+- `queenRelationshipState` at +1419, length 1 (High)
+- `queenPortraitIndex` at +1420, length 1 (High)
+- `queenNextRelationshipCheckTurn` at +1421, length 2 (High)
 
 Other bytes unknown/reserved (Low).
 
 ### Army (725 bytes)
 Known fields:
-- `x` +0 (Medium)
-- `y` +2 (Medium)
-- `player` +4 (Medium)
-- `dir` +5 (Low/Medium)
+- `tileRow` +0, length 2 (High)
+- `tileColumn` +2, length 2 (High)
+- `ownerPlayerIndex` +4, length 1 (High)
+- `facingDirection` +5, length 1 (High)
 - `units` +6, count 10, entry size 31 (High for layout)
+- `queuedPathWaypointCount` +316, length 4 (High)
+- `isHiddenOnWorldMap` +720, length 1 (High)
 
 Remaining bytes unknown/reserved (Low).
 
 ### Unit (31 bytes)
 Known fields:
-- `typeId` +0 (High for occupancy marker)
+- `typeId` +0, length 2 (High for occupancy marker, `-1` empty)
 - `ownerPlayerIndex` +2 (High)
 - `currentActionPoints` +8 (High)
 - `currentHealthPercent` +9 (High)
@@ -59,18 +75,21 @@ Known fields:
 - `morale` +11 (High)
 - `stanceBits` +12 (Medium/High)
 - `stateFlags` +13 (Medium/High)
+- `auxRuntimeState` +18, length 4 (High for layout)
+- `stateBits2` +22, length 1 (High for layout)
 
 Remaining bytes unknown/reserved (Low).
 
 ### Castle (467 bytes)
 Known fields:
-- `x` +0 (High)
-- `y` +1 (High)
-- `player` +2 (High)
+- `tileRow` +0 (High)
+- `tileColumn` +1 (High)
+- `ownerPlayerIndex` +2 (High)
 - `appearance` +3 (Low/Medium)
-- `type` +4 (High for occupancy marker)
-- `name` +5, length 10 (High)
+- `footprintClass` +4 (High for occupancy marker)
+- `displayName` +5, length 10 (High)
 - `units` +18, count 12, entry size 31 (High for layout)
+- `garrisonOrderBytes` +390, length 12 (High for layout)
 - `addonTypeIds` +402, length 12 (High)
 - `selectedAddonSlotIndex` +414 (High)
 - `castleAddonFlags` +416 (High)
@@ -83,6 +102,7 @@ Known fields:
 - `taxRate` +436, low 6 bits (High)
 - `storedMoney` +438, length 4 (High)
 - `techLevelBits` +444, low 3 bits (High)
+- `prisonerSlotsRaw` +445, length 18 (High for layout)
 - `castleFactId` +463, length 4 (High)
 
 Remaining bytes unknown/reserved (Low).

--- a/src/com/lis/clash/clash.kt
+++ b/src/com/lis/clash/clash.kt
@@ -24,6 +24,7 @@ class ClashSaveEditor(title: String) : JFrame() {
     private lateinit var selectionController: SelectionController
 
     private lateinit var save: Save
+    private var tileNavigationBound = false
 
     init {
         createUI(title)
@@ -94,11 +95,16 @@ class ClashSaveEditor(title: String) : JFrame() {
         }
         Scripts::class.functions
             .filter { it.hasAnnotation<ClashScript>() }
+            .sortedBy { it.name }
             .forEach {
                 clashGUI.scriptBox.addItem(FunctionWrapper(it))
             }
 
         clashGUI.executeButton.addActionListener {
+            if (!::save.isInitialized) {
+                println("Load a save before executing scripts")
+                return@addActionListener
+            }
             println(
                 (clashGUI.scriptBox.selectedItem as FunctionWrapper).function.call(
                     Scripts::class.objectInstance,
@@ -128,6 +134,14 @@ class ClashSaveEditor(title: String) : JFrame() {
 
     private fun initializeMap() {
         clashGUI.mapPanel.tiles = { save.tiles }
+        clashGUI.mapPanel.mapWidth = { save.mapWidthTiles.takeIf { it > 0 } ?: 100 }
+        clashGUI.mapPanel.mapHeight = { save.mapHeightTiles.takeIf { it > 0 } ?: 100 }
+        clashGUI.mapPanel.selectedTileIndex = { clashGUI.tilesTable.selectedRow }
+        clashGUI.mapPanel.onTileSelected = { tileIndex ->
+            selectTile(tileIndex)
+        }
+        clashGUI.mapPanel.revalidate()
+        clashGUI.mapPanel.repaint()
     }
 
     private fun initializeUnits() {
@@ -141,27 +155,41 @@ class ClashSaveEditor(title: String) : JFrame() {
         clashGUI.tilesTable.withData { save.tiles }
             .withSelectionController(selectionController)
             .withSelectionListener {
-                clashGUI.getxTile().text = fromIndex(it).first.toString()
-                clashGUI.getyTile().text = fromIndex(it).second.toString()
-
+                if (it >= 0) {
+                    val (tileRow, tileColumn) = fromIndex(it, save.mapWidthTiles.takeIf { width -> width > 0 } ?: 100)
+                    clashGUI.getxTile().text = tileRow.toString()
+                    clashGUI.getyTile().text = tileColumn.toString()
+                }
+                clashGUI.mapPanel.repaint()
             }
 
-        clashGUI.getxTile().addActionListener {
-            val i = toIndex(clashGUI.getxTile().text.toInt(), clashGUI.getyTile().text.toInt())
-            clashGUI.tilesTable.setRowSelectionInterval(i, i)
-            clashGUI.tilesTable.scrollRectToVisible(clashGUI.tilesTable.getCellRect(i, 0, true))
-        }
-
-        clashGUI.getyTile().addActionListener {
-            val i = toIndex(clashGUI.getxTile().text.toInt(), clashGUI.getyTile().text.toInt())
-            clashGUI.tilesTable.setRowSelectionInterval(i, i)
-            clashGUI.tilesTable.scrollRectToVisible(clashGUI.tilesTable.getCellRect(i, 0, true))
+        if (!tileNavigationBound) {
+            val tileNavigator = fun() {
+                if (!::save.isInitialized) {
+                    return
+                }
+                val mapWidth = save.mapWidthTiles.takeIf { it > 0 } ?: 100
+                val tileIndex = toIndex(clashGUI.getxTile().text.toInt(), clashGUI.getyTile().text.toInt(), mapWidth)
+                selectTile(tileIndex)
+            }
+            clashGUI.getxTile().addActionListener { tileNavigator() }
+            clashGUI.getyTile().addActionListener { tileNavigator() }
+            tileNavigationBound = true
         }
     }
 
     private fun initializePlayers() {
         clashGUI.playersTable.withData { save.players }
             .withSelectionController(selectionController)
+    }
+
+    private fun selectTile(tileIndex: Int) {
+        if (tileIndex !in save.tiles.indices) {
+            return
+        }
+        clashGUI.tilesTable.setRowSelectionInterval(tileIndex, tileIndex)
+        clashGUI.tilesTable.scrollRectToVisible(clashGUI.tilesTable.getCellRect(tileIndex, 0, true))
+        clashGUI.mapPanel.repaint()
     }
 }
 

--- a/src/com/lis/clash/converters.kt
+++ b/src/com/lis/clash/converters.kt
@@ -30,6 +30,21 @@ internal fun writeLittleEndianInt(value: Int, length: Int): List<Byte> {
     }
 }
 
+internal fun readLittleEndianSignedInt(bytes: List<Byte>): Int {
+    val unsignedValue = readLittleEndianInt(bytes)
+    if (bytes.isEmpty() || bytes.size >= 4) {
+        return unsignedValue
+    }
+
+    val bitCount = bytes.size * 8
+    val signBit = 1 shl (bitCount - 1)
+    return if ((unsignedValue and signBit) != 0) {
+        unsignedValue - (1 shl bitCount)
+    } else {
+        unsignedValue
+    }
+}
+
 object ByteConverter : Converter {
     override fun toString(t: Any): String {
         return t.toString()
@@ -54,7 +69,12 @@ object ListConverter : Converter {
     }
 
     override fun fromString(s: String): Any {
-        return s.subSequence(1, s.length - 2).split(",").map { it.toByte() }
+        if (s == "[]") {
+            return emptyList<Byte>()
+        }
+        return s.subSequence(1, s.length - 1)
+            .split(",")
+            .map { it.trim().toByte() }
     }
 
     override fun toBytes(t: Any, length: Int): List<Byte> {
@@ -77,11 +97,12 @@ object StringConverter : Converter {
     }
 
     override fun toBytes(t: Any, length: Int): List<Byte> {
-        return (t as String).toByteArray().toList()
+        val encoded = (t as String).toByteArray().toList().take(length)
+        return encoded + List((length - encoded.size).coerceAtLeast(0)) { 0 }
     }
 
     override fun fromBytes(s: List<Byte>, length: Int): Any {
-        return String(s.toByteArray())
+        return String(s.toByteArray()).trimEnd('\u0000')
     }
 
 }
@@ -104,4 +125,22 @@ object IntConverter : Converter {
         return readLittleEndianInt(s.take(length))
     }
 
+}
+
+object SignedIntConverter : Converter {
+    override fun toString(t: Any): String {
+        return t.toString()
+    }
+
+    override fun fromString(s: String): Any {
+        return s.toInt()
+    }
+
+    override fun toBytes(t: Any, length: Int): List<Byte> {
+        return writeLittleEndianInt(t as Int, length)
+    }
+
+    override fun fromBytes(s: List<Byte>, length: Int): Any {
+        return readLittleEndianSignedInt(s.take(length))
+    }
 }

--- a/src/com/lis/clash/map.kt
+++ b/src/com/lis/clash/map.kt
@@ -2,41 +2,116 @@ package com.lis.clash
 
 import com.lis.clash.objects.Tile
 import java.awt.Color
+import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
 
-fun toIndex(x: Int, y: Int): Int {
-    return x * 100 + y
+fun toIndex(tileRow: Int, tileColumn: Int, mapWidth: Int = 100): Int {
+    return tileRow * mapWidth + tileColumn
 }
 
-fun fromIndex(index: Int): Pair<Int, Int> {
-    return index / 100 to index % 100
+fun fromIndex(index: Int, mapWidth: Int = 100): Pair<Int, Int> {
+    return index / mapWidth to index % mapWidth
 }
 
 
 class MapPanel : JPanel() {
     var tiles: () -> List<Tile> = { emptyList() }
-    val size = 5
+    var mapWidth: () -> Int = { 100 }
+    var mapHeight: () -> Int = { 100 }
+    var selectedTileIndex: () -> Int = { -1 }
+    var onTileSelected: (Int) -> Unit = {}
+    private val tileSize = 5
 
     init {
         addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
-                println(Pair(e.x / size, e.y / size))
+                val width = resolvedMapWidth()
+                val height = resolvedMapHeight(width)
+                val tileRow = e.x / tileSize
+                val tileColumn = e.y / tileSize
+                if (tileRow in 0 until width && tileColumn in 0 until height) {
+                    val tileIndex = toIndex(tileRow, tileColumn, width)
+                    if (tileIndex in tiles().indices) {
+                        onTileSelected(tileIndex)
+                    }
+                }
             }
-
         })
     }
 
+    override fun getPreferredSize(): Dimension {
+        val width = resolvedMapWidth()
+        val height = resolvedMapHeight(width)
+        return Dimension(width * tileSize, height * tileSize)
+    }
+
     override fun paintComponent(g: Graphics) {
+        super.paintComponent(g)
+        val width = resolvedMapWidth()
+        val height = resolvedMapHeight(width)
+        val highlightedTileIndex = selectedTileIndex()
         tiles().forEachIndexed { index, tile ->
-            val colorByte = tile.type1.toUByte().toInt()
-            val y = fromIndex(index).second
-            val x = fromIndex(index).first
-            g.color = (Color(colorByte, colorByte, colorByte))
-            g.fillRect(x * size, y * size, size, size)
+            val (tileRow, tileColumn) = fromIndex(index, width)
+            if (tileColumn >= height) {
+                return@forEachIndexed
+            }
+
+            val x = tileRow * tileSize
+            val y = tileColumn * tileSize
+
+            g.color = colorForTerrain(tile.terrainTileId)
+            g.fillRect(x, y, tileSize, tileSize)
+
+            if (tile.hasOverlay()) {
+                g.color = colorForOverlay(tile.overlayTileId)
+                g.fillRect(x + 1, y + 1, (tileSize - 2).coerceAtLeast(1), (tileSize - 2).coerceAtLeast(1))
+            }
+
+            if (tile.hasRoadOrBridge()) {
+                g.color = colorForRoadOrBridge(tile.roadOrBridgeTileId)
+                g.drawLine(x, y + tileSize / 2, x + tileSize - 1, y + tileSize / 2)
+                g.drawLine(x + tileSize / 2, y, x + tileSize / 2, y + tileSize - 1)
+            }
+
+            if (index == highlightedTileIndex) {
+                g.color = Color.RED
+                g.drawRect(x, y, tileSize - 1, tileSize - 1)
+            }
         }
     }
-}
 
+    private fun resolvedMapWidth(): Int {
+        val resolved = mapWidth()
+        return if (resolved > 0) resolved else 100
+    }
+
+    private fun resolvedMapHeight(width: Int): Int {
+        val resolved = mapHeight()
+        if (resolved > 0) {
+            return resolved
+        }
+        val tileCount = tiles().size
+        return if (tileCount == 0) 1 else (tileCount + width - 1) / width
+    }
+
+    private fun colorForTerrain(terrainTileId: Int): Color {
+        if (terrainTileId == 0xFFFF) {
+            return Color(24, 24, 24)
+        }
+        val hue = ((terrainTileId * 37) % 360) / 360.0f
+        return Color.getHSBColor(hue, 0.35f, 0.82f)
+    }
+
+    private fun colorForOverlay(overlayTileId: Int): Color {
+        val hue = ((overlayTileId * 53 + 90) % 360) / 360.0f
+        return Color.getHSBColor(hue, 0.55f, 0.95f)
+    }
+
+    private fun colorForRoadOrBridge(roadOrBridgeTileId: Int): Color {
+        val hue = ((roadOrBridgeTileId * 17 + 24) % 60) / 360.0f
+        return Color.getHSBColor(hue, 0.85f, 0.9f)
+    }
+}

--- a/src/com/lis/clash/objects/Army.kt
+++ b/src/com/lis/clash/objects/Army.kt
@@ -3,22 +3,40 @@ package com.lis.clash.objects
 import com.lis.clash.*
 
 class Army(parent: ClashObject, index: Int) : ClashObject(parent, index) {
-    @ClashSimpleProperty(0, 1)
-    var x: Byte by clashProperty(0)
+    @ClashSimpleProperty(0, 2)
+    var tileRow: Int by clashProperty(0)
 
-    @ClashSimpleProperty(2, 1)
-    var y: Byte by clashProperty(0)
+    @ClashSimpleProperty(2, 2)
+    var tileColumn: Int by clashProperty(0)
 
     @ClashSimpleProperty(4, 1)
-    var player: Byte by clashProperty(0)
+    var ownerPlayerIndex: Int by clashProperty(0)
 
     @ClashSimpleProperty(5, 1)
-    var dir: Byte by clashProperty(0)
+    var facingDirection: Int by clashProperty(0)
 
     @ClashAggregateProperty(6, 10, 31, Unit::class)
     var units: List<Unit> by clashProperty(emptyList())
 
+    @ClashSimpleProperty(316, 4)
+    var queuedPathWaypointCount: Int by clashProperty(0)
+
+    @ClashSimpleProperty(720, 1)
+    var isHiddenOnWorldMap: Int by clashProperty(0)
+
+    fun queuedPathWaypoints(): List<QueuedPathWaypoint> {
+        val count = queuedPathWaypointCount.coerceIn(0, 100)
+        return List(count) { waypointIndex ->
+            val baseIndex = 320 + waypointIndex * 4
+            QueuedPathWaypoint(
+                tileRow = bytes[baseIndex].toUByte().toInt(),
+                tileColumn = bytes[baseIndex + 1].toUByte().toInt(),
+                cumulativeCost = readLittleEndianInt(bytes.slice(baseIndex + 2 until baseIndex + 4))
+            )
+        }
+    }
+
     override fun isValid(): Boolean {
-        return units.isNotEmpty();
+        return units.isNotEmpty()
     }
 }

--- a/src/com/lis/clash/objects/Castle.kt
+++ b/src/com/lis/clash/objects/Castle.kt
@@ -1,7 +1,10 @@
 package com.lis.clash.objects
 
 import com.lis.clash.ClashAggregateProperty
+import com.lis.clash.GarrisonOrder
 import com.lis.clash.ClashMaskedProperty
+import com.lis.clash.RawSixByteRecord
+import com.lis.clash.ClashSignedProperty
 import com.lis.clash.ClashSimpleProperty
 
 class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
@@ -15,30 +18,33 @@ class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     }
 
     @ClashSimpleProperty(0, 1)
-    var x: Byte by clashProperty(0)
+    var tileRow: Int by clashProperty(0)
 
     @ClashSimpleProperty(1, 1)
-    var y: Byte by clashProperty(0)
+    var tileColumn: Int by clashProperty(0)
 
     @ClashSimpleProperty(2, 1)
-    var player: Byte by clashProperty(0)
+    var ownerPlayerIndex: Int by clashProperty(0)
 
     @ClashSimpleProperty(3, 1)
-    var appearance: Byte by clashProperty(0)
+    var appearance: Int by clashProperty(0)
 
-    @ClashSimpleProperty(4, 1)
-    var type: Byte by clashProperty(0)
+    @ClashSignedProperty(4, 1)
+    var footprintClass: Int by clashProperty(0)
 
     @ClashSimpleProperty(5, 10)
-    var name: String by clashProperty("")
+    var displayName: String by clashProperty("")
 
     @ClashAggregateProperty(18, 12, 31, Unit::class)
     var units: List<Unit> by clashProperty(emptyList())
 
+    @ClashSimpleProperty(390, 12)
+    var garrisonOrderBytes: List<Byte> by clashProperty(emptyList())
+
     @ClashSimpleProperty(402, 12)
     var addonTypeIds: List<Byte> by clashProperty(emptyList())
 
-    @ClashSimpleProperty(414, 1)
+    @ClashSignedProperty(414, 1)
     var selectedAddonSlotIndex: Int by clashProperty(0)
 
     @ClashSimpleProperty(416, 1)
@@ -71,6 +77,9 @@ class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     @ClashMaskedProperty(444, 1, 0x07)
     var techLevelBits: Int by clashProperty(0)
 
+    @ClashSimpleProperty(445, 18)
+    var prisonerSlotsRaw: List<Byte> by clashProperty(emptyList())
+
     @ClashSimpleProperty(463, 4)
     var castleFactId: Int by clashProperty(0)
 
@@ -88,7 +97,17 @@ class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
         return result
     }
 
+    fun garrisonOrders(): List<GarrisonOrder> {
+        return garrisonOrderBytes.map { raw ->
+            GarrisonOrder(raw.toInt() and 0xFF)
+        }
+    }
+
+    fun prisonerSlots(): List<RawSixByteRecord> {
+        return prisonerSlotsRaw.chunked(6).map(::RawSixByteRecord)
+    }
+
     override fun isValid(): Boolean {
-        return type.toInt() != -1
+        return footprintClass != -1
     }
 }

--- a/src/com/lis/clash/objects/Player.kt
+++ b/src/com/lis/clash/objects/Player.kt
@@ -2,6 +2,7 @@ package com.lis.clash.objects
 
 import com.lis.clash.ClashMaskedProperty
 import com.lis.clash.ClashSimpleProperty
+import com.lis.clash.RawSixByteRecord
 
 class Player(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     @ClashSimpleProperty(0, 4)
@@ -39,4 +40,20 @@ class Player(parent: ClashObject, index: Int) : ClashObject(parent, index) {
 
     @ClashSimpleProperty(57, 1300)
     var revealedTilesBitset: List<Byte> by clashProperty(emptyList())
+
+    @ClashSimpleProperty(1357, 60)
+    var prisonerTransferQueueRaw: List<Byte> by clashProperty(emptyList())
+
+    @ClashSimpleProperty(1419, 1)
+    var queenRelationshipState: Int by clashProperty(0)
+
+    @ClashSimpleProperty(1420, 1)
+    var queenPortraitIndex: Int by clashProperty(0)
+
+    @ClashSimpleProperty(1421, 2)
+    var queenNextRelationshipCheckTurn: Int by clashProperty(0)
+
+    fun prisonerTransferQueueEntries(): List<RawSixByteRecord> {
+        return prisonerTransferQueueRaw.chunked(6).map(::RawSixByteRecord)
+    }
 }

--- a/src/com/lis/clash/objects/Save.kt
+++ b/src/com/lis/clash/objects/Save.kt
@@ -10,11 +10,32 @@ class Save : ClashObject(null, 0) {
     @ClashAggregateProperty(16, 10000, 14, Tile::class)
     var tiles: List<Tile> by clashProperty(emptyList())
 
+    @ClashSimpleProperty(140000, 4)
+    var mapWidthTiles: Int by clashProperty(0)
+
+    @ClashSimpleProperty(140004, 4)
+    var mapHeightTiles: Int by clashProperty(0)
+
+    @ClashSimpleProperty(140008, 4)
+    var mapViewLeft: Int by clashProperty(0)
+
+    @ClashSimpleProperty(140012, 4)
+    var mapViewTop: Int by clashProperty(0)
+
+    @ClashSimpleProperty(140017, 4)
+    var activeMissionIndex: Int by clashProperty(0)
+
     @ClashAggregateProperty(147190, 500, 725, Army::class)
     var armies: List<Army> by clashProperty(emptyList())
 
     @ClashAggregateProperty(140040, 5, 1423, Player::class)
     var players: List<Player> by clashProperty(emptyList())
+
+    @ClashSimpleProperty(147139, 4)
+    var turnOwnerPlayerIndex: Int by clashProperty(0)
+
+    @ClashSimpleProperty(147143, 4)
+    var viewedPlayerIndex: Int by clashProperty(0)
 
     @ClashAggregateProperty(509690, 10, 467, Castle::class)
     var castles: List<Castle> by clashProperty(emptyList())

--- a/src/com/lis/clash/objects/Tile.kt
+++ b/src/com/lis/clash/objects/Tile.kt
@@ -4,16 +4,20 @@ import com.lis.clash.ClashSimpleProperty
 
 class Tile(parent: ClashObject, index: Int) : ClashObject(parent, index) {
 
-    @ClashSimpleProperty(0, 1)
-    var type1: Byte by clashProperty(0)
+    @ClashSimpleProperty(0, 2)
+    var terrainTileId: Int by clashProperty(0)
 
-    @ClashSimpleProperty(1, 1)
-    var type2: Byte by clashProperty(0)
+    @ClashSimpleProperty(2, 2)
+    var overlayTileId: Int by clashProperty(0)
 
-    @ClashSimpleProperty(2, 1)
-    var type3: Byte by clashProperty(0)
+    @ClashSimpleProperty(4, 2)
+    var roadOrBridgeTileId: Int by clashProperty(0)
 
-    @ClashSimpleProperty(3, 1)
-    var type4: Byte by clashProperty(0)
+    fun hasOverlay(): Boolean {
+        return overlayTileId != 0xFFFF
+    }
 
+    fun hasRoadOrBridge(): Boolean {
+        return roadOrBridgeTileId != 0xFFFF
+    }
 }

--- a/src/com/lis/clash/objects/Unit.kt
+++ b/src/com/lis/clash/objects/Unit.kt
@@ -1,9 +1,10 @@
 package com.lis.clash.objects
 
+import com.lis.clash.ClashSignedProperty
 import com.lis.clash.ClashSimpleProperty
 
 class Unit(parent: ClashObject, index: Int) : ClashObject(parent, index) {
-    @ClashSimpleProperty(0, 1)
+    @ClashSignedProperty(0, 2)
     var typeId: Int by clashProperty(0)
 
     @ClashSimpleProperty(2, 1)
@@ -27,8 +28,14 @@ class Unit(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     @ClashSimpleProperty(13, 1)
     var stateFlags: Int by clashProperty(0)
 
+    @ClashSimpleProperty(18, 4)
+    var auxRuntimeState: Int by clashProperty(0)
+
+    @ClashSimpleProperty(22, 1)
+    var stateBits2: Int by clashProperty(0)
+
     override fun isValid(): Boolean {
-        return typeId != 0xFF
+        return typeId != -1
     }
 
 }

--- a/src/com/lis/clash/parser.kt
+++ b/src/com/lis/clash/parser.kt
@@ -12,6 +12,8 @@ import kotlin.reflect.jvm.jvmErasure
 
 annotation class ClashSimpleProperty(val index: Int, val length: Int)
 
+annotation class ClashSignedProperty(val index: Int, val length: Int)
+
 annotation class ClashMaskedProperty(
     val index: Int,
     val length: Int,
@@ -89,6 +91,26 @@ class SimplePropertyDescriptor(_property: KMutableProperty<ClashObject>) : Clash
 
     override fun getConverter(): Converter {
         return converters[_property.getter.returnType.jvmErasure]!!
+    }
+}
+
+class SignedPropertyDescriptor(_property: KMutableProperty<ClashObject>) : ClashPropertyDescriptor(_property) {
+    private val annotation: ClashSignedProperty = _property.findAnnotation()!!
+
+    override fun index(): Int {
+        return annotation.index
+    }
+
+    override fun length(): Int {
+        return annotation.length
+    }
+
+    override fun isSimple(): Boolean {
+        return true
+    }
+
+    override fun getConverter(): Converter {
+        return SignedIntConverter
     }
 }
 
@@ -217,6 +239,8 @@ object AnnotationParser {
     private fun parseProperty(property: KMutableProperty<ClashObject>): ClashPropertyDescriptor? {
         if (property.hasAnnotation<ClashSimpleProperty>()) {
             return SimplePropertyDescriptor(property)
+        } else if (property.hasAnnotation<ClashSignedProperty>()) {
+            return SignedPropertyDescriptor(property)
         } else if (property.hasAnnotation<ClashMaskedProperty>()) {
             return MaskedPropertyDescriptor(property)
         } else if (property.hasAnnotation<ClashAggregateProperty>()) {

--- a/src/com/lis/clash/scripts.kt
+++ b/src/com/lis/clash/scripts.kt
@@ -1,7 +1,9 @@
 package com.lis.clash
 
-import com.lis.clash.objects.ClashObject
+import com.lis.clash.objects.Army
 import com.lis.clash.objects.Castle
+import com.lis.clash.objects.ClashObject
+import com.lis.clash.objects.Player
 import com.lis.clash.objects.Save
 import com.lis.clash.objects.Tile
 import com.lis.clash.objects.Unit
@@ -9,36 +11,13 @@ import java.io.File
 
 annotation class ClashScript
 
+private const val DEFAULT_LIST_LIMIT = 200
+
 object Scripts {
     @ClashScript
-    fun setTiles(save: Save) {
-        save.tiles.stream().forEach {
-            it.type1 = 0
-            it.type2 = 1
-            it.type3 = -1
-            it.type4 = -1
-        }
-
-    }
-
-    @ClashScript
-    fun findTreasures(save: Save): List<Pair<Int, Int>> {
-        return save.tiles.mapIndexed { index, tile ->
-            index to tile
-        }.filter { TILE.TREASURE.matches(it.second) }
-            .map { fromIndex(it.first) }
-    }
-
-    @ClashScript
-    fun countTiles(save: Save): Set<Pair<Byte, Byte>> {
-        return save.tiles.map { it.type3 to it.type4 }
-            .toSortedSet(compareBy<Pair<Byte, Byte>> { it.first }.thenBy { it.second })
-    }
-
-    @ClashScript
     fun exploreAll(save: Save) {
-        return save.players.forEach {
-            it.revealedTilesBitset = List(1300) { Integer.valueOf(255).toByte() }
+        save.players.forEach { player ->
+            player.revealedTilesBitset = List(1300) { 0xFF.toByte() }
         }
     }
 
@@ -55,6 +34,14 @@ object Scripts {
     }
 
     @ClashScript
+    fun listCargoUnits(save: Save): String {
+        return formatLocatedUnits(
+            title = "Cargo units",
+            units = save.locatedUnits().filter { it.metadata?.hasCategory(UnitCategory.CARGO) == true }
+        )
+    }
+
+    @ClashScript
     fun listCastleBuildings(save: Save): String {
         if (save.castles.isEmpty()) {
             return "No castles found"
@@ -62,12 +49,313 @@ object Scripts {
 
         return save.castles.joinToString("\n") { castle ->
             val buildings = castle.buildingNames().ifEmpty { listOf("none") }
-            val x = castle.x.toInt() and 0xFF
-            val y = castle.y.toInt() and 0xFF
-            val owner = castle.player.toInt() and 0xFF
-            val wallLevel = castle.wallStrength and 0xFF
-            "Castle(${x},${y}) owner=${owner} walls=${wallLevel} buildings=${buildings.joinToString(",")}"
+            "Castle(${castle.tileRow},${castle.tileColumn}) owner=${castle.ownerPlayerIndex} walls=${castle.wallStrength} buildings=${buildings.joinToString(",")}"
         }
+    }
+
+    @ClashScript
+    fun listDamagedUnits(save: Save): String {
+        return formatLocatedUnits(
+            title = "Damaged units",
+            units = save.locatedUnits().filter { it.unit.currentHealthPercent < 100 }
+        )
+    }
+
+    @ClashScript
+    fun listExhaustedUnits(save: Save): String {
+        return formatLocatedUnits(
+            title = "Exhausted units",
+            units = save.locatedUnits().filter { it.unit.fatigue >= 80 }
+        )
+    }
+
+    @ClashScript
+    fun listFlyingUnits(save: Save): String {
+        return formatLocatedUnits(
+            title = "Flying units",
+            units = save.locatedUnits().filter { it.metadata?.hasCategory(UnitCategory.FLYING) == true }
+        )
+    }
+
+    @ClashScript
+    fun listHiddenArmyStacks(save: Save): String {
+        val hiddenArmies = save.armies.mapIndexed { armyIndex, army -> armyIndex to army }
+            .filter { (_, army) -> army.isHiddenOnWorldMap != 0 }
+
+        if (hiddenArmies.isEmpty()) {
+            return "Hidden army stacks: none"
+        }
+
+        val lines = hiddenArmies.map { (armyIndex, army) ->
+            "army#$armyIndex row=${army.tileRow} column=${army.tileColumn} owner=${army.ownerPlayerIndex} units=${army.units.size} queuedWaypoints=${army.queuedPathWaypointCount}"
+        }
+        return renderSection("Hidden army stacks", hiddenArmies.size, lines)
+    }
+
+    @ClashScript
+    fun listLowMoraleUnits(save: Save): String {
+        return formatLocatedUnits(
+            title = "Low-morale units",
+            units = save.locatedUnits().filter { it.unit.morale <= 6 }
+        )
+    }
+
+    @ClashScript
+    fun listQueuedArmyPaths(save: Save): String {
+        val queuedArmies = save.armies.mapIndexed { armyIndex, army -> armyIndex to army }
+            .filter { (_, army) -> army.queuedPathWaypointCount > 0 }
+
+        if (queuedArmies.isEmpty()) {
+            return "Queued army paths: none"
+        }
+
+        val lines = queuedArmies.map { (armyIndex, army) ->
+            val waypointPreview = army.queuedPathWaypoints()
+                .take(5)
+                .joinToString(" -> ") { waypoint ->
+                    "(${waypoint.tileRow},${waypoint.tileColumn};cost=${waypoint.cumulativeCost})"
+                }
+                .ifEmpty { "no decoded waypoints" }
+            "army#$armyIndex row=${army.tileRow} column=${army.tileColumn} owner=${army.ownerPlayerIndex} hidden=${army.isHiddenOnWorldMap} waypointCount=${army.queuedPathWaypointCount} preview=$waypointPreview"
+        }
+        return renderSection("Queued army paths", queuedArmies.size, lines)
+    }
+
+    @ClashScript
+    fun listQueuedPrisonerTransfers(save: Save): String {
+        val lines = save.players.mapIndexedNotNull { playerIndex, player ->
+            val nonEmptyEntries = player.prisonerTransferQueueEntries().mapIndexedNotNull { entryIndex, entry ->
+                if (entry.isEmpty) {
+                    null
+                } else {
+                    "entry#$entryIndex=${entry.rawBytes.toUnsignedSummary()}"
+                }
+            }
+            if (nonEmptyEntries.isEmpty()) {
+                null
+            } else {
+                "player#$playerIndex name=\"${player.displayName}\" ${nonEmptyEntries.joinToString(" ")}"
+            }
+        }
+
+        if (lines.isEmpty()) {
+            return "Queued prisoner transfers: none"
+        }
+
+        return renderSection("Queued prisoner transfers", lines.size, lines)
+    }
+
+    @ClashScript
+    fun listSpecialPersonageUnits(save: Save): String {
+        return formatLocatedUnits(
+            title = "Special personage units",
+            units = save.locatedUnits().filter { it.metadata?.hasCategory(UnitCategory.SPECIAL_PERSONAGE) == true }
+        )
+    }
+
+    @ClashScript
+    fun listTilesWithOverlays(save: Save): String {
+        return formatLocatedTiles(
+            title = "Tiles with overlays",
+            tiles = save.locatedTiles().filter { it.tile.hasOverlay() }
+        ) { locatedTile ->
+            "terrain=${formatTileId(locatedTile.tile.terrainTileId)} overlay=${formatTileId(locatedTile.tile.overlayTileId)}"
+        }
+    }
+
+    @ClashScript
+    fun listTilesWithRoadsOrBridges(save: Save): String {
+        return formatLocatedTiles(
+            title = "Tiles with roads or bridges",
+            tiles = save.locatedTiles().filter { it.tile.hasRoadOrBridge() }
+        ) { locatedTile ->
+            "terrain=${formatTileId(locatedTile.tile.terrainTileId)} roadOrBridge=${formatTileId(locatedTile.tile.roadOrBridgeTileId)}"
+        }
+    }
+
+    @ClashScript
+    fun listUnitsWithAuxRuntimeState(save: Save): String {
+        return formatLocatedUnits(
+            title = "Units with aux runtime state",
+            units = save.locatedUnits().filter { it.unit.auxRuntimeState != 0 }
+        ) { locatedUnit ->
+            "auxRuntimeState=${locatedUnit.unit.auxRuntimeState.toHex(8)}"
+        }
+    }
+
+    @ClashScript
+    fun listUnitsWithStateBits2(save: Save): String {
+        return formatLocatedUnits(
+            title = "Units with stateBits2",
+            units = save.locatedUnits().filter { it.unit.stateBits2 != 0 }
+        ) { locatedUnit ->
+            "stateBits2=${locatedUnit.unit.stateBits2.toHex(2)}"
+        }
+    }
+
+    @ClashScript
+    fun listUnitsWithStateFlags(save: Save): String {
+        return formatLocatedUnits(
+            title = "Units with state flags",
+            units = save.locatedUnits().filter { it.unit.stateFlags != 0 }
+        ) { locatedUnit ->
+            "stateFlags=${locatedUnit.unit.stateFlags.toHex(2)}"
+        }
+    }
+
+    @ClashScript
+    fun summarizeArmyStacks(save: Save): String {
+        val ownerCounts = save.armies.groupingBy { it.ownerPlayerIndex }.eachCount()
+        return buildString {
+            appendLine("Army stacks")
+            appendLine("total=${save.armies.size}")
+            appendLine("hidden=${save.armies.count { it.isHiddenOnWorldMap != 0 }}")
+            appendLine("withQueuedPath=${save.armies.count { it.queuedPathWaypointCount > 0 }}")
+            appendLine("owners=${ownerCounts.entries.sortedBy { it.key }.joinToString(",") { "p${it.key}=${it.value}" }}")
+        }.trimEnd()
+    }
+
+    @ClashScript
+    fun summarizeCastleAddonFlags(save: Save): String {
+        if (save.castles.isEmpty()) {
+            return "Castle add-on flags: none"
+        }
+
+        val lines = save.castles.mapIndexed { castleIndex, castle ->
+            val buildings = castle.buildingNames().ifEmpty { listOf("none") }
+            "castle#$castleIndex row=${castle.tileRow} column=${castle.tileColumn} owner=${castle.ownerPlayerIndex} flags=${castle.castleAddonFlags.toHex(2)} buildings=${buildings.joinToString(",")}"
+        }
+        return renderSection("Castle add-on flags", save.castles.size, lines)
+    }
+
+    @ClashScript
+    fun summarizeCastleGarrisonOrders(save: Save): String {
+        if (save.castles.isEmpty()) {
+            return "Castle garrison orders: none"
+        }
+
+        val lines = save.castles.mapIndexed { castleIndex, castle ->
+            val activeOrders = castle.garrisonOrders().mapIndexedNotNull { slotIndex, order ->
+                if (order.rawValue == 0) {
+                    null
+                } else {
+                    "slot#$slotIndex(raw=${order.rawValue.toHex(2)},train=${order.trainCountdown},repair=${order.repairCountdown})"
+                }
+            }
+            "castle#$castleIndex row=${castle.tileRow} column=${castle.tileColumn} activeOrders=${activeOrders.size}${if (activeOrders.isEmpty()) "" else " ${activeOrders.joinToString(" ")}"}"
+        }
+        return renderSection("Castle garrison orders", save.castles.size, lines)
+    }
+
+    @ClashScript
+    fun summarizeOverlayTileIds(save: Save): String {
+        return summarizeTileField(
+            title = "Overlay tile ids",
+            ids = save.tiles.mapNotNull { tile -> tile.overlayTileId.takeUnless { it == 0xFFFF } }
+        )
+    }
+
+    @ClashScript
+    fun summarizePlayerExploration(save: Save): String {
+        val activePlayers = save.players.mapIndexed { playerIndex, player -> playerIndex to player }
+            .filter { (_, player) -> player.isActive != 0 }
+
+        if (activePlayers.isEmpty()) {
+            return "Player exploration: no active players"
+        }
+
+        val mapTileCount = save.mapWidthOrDefault() * save.mapHeightOrDefault()
+        val lines = activePlayers.map { (playerIndex, player) ->
+            val revealedTileCount = player.revealedTilesBitset.sumOf { countBits(it) }
+            val coverage = if (mapTileCount == 0) 0.0 else revealedTileCount * 100.0 / mapTileCount
+            "player#$playerIndex name=\"${player.displayName}\" revealed=$revealedTileCount/${mapTileCount} coverage=${"%.2f".format(coverage)}% queenState=${player.queenRelationshipState.toHex(2)}"
+        }
+        return renderSection("Player exploration", activePlayers.size, lines)
+    }
+
+    @ClashScript
+    fun summarizeRoadOrBridgeTileIds(save: Save): String {
+        return summarizeTileField(
+            title = "Road or bridge tile ids",
+            ids = save.tiles.mapNotNull { tile -> tile.roadOrBridgeTileId.takeUnless { it == 0xFFFF } }
+        )
+    }
+
+    @ClashScript
+    fun summarizeTerrainTileIds(save: Save): String {
+        return summarizeTileField(
+            title = "Terrain tile ids",
+            ids = save.tiles.map { it.terrainTileId }
+        )
+    }
+
+    @ClashScript
+    fun summarizeTileCombinations(save: Save): String {
+        val counts = save.tiles.groupingBy { tile ->
+            Triple(tile.terrainTileId, tile.overlayTileId, tile.roadOrBridgeTileId)
+        }.eachCount()
+
+        if (counts.isEmpty()) {
+            return "Tile combinations: none"
+        }
+
+        val lines = counts.entries
+            .sortedWith(compareByDescending<Map.Entry<Triple<Int, Int, Int>, Int>> { it.value }.thenBy { it.key.first }.thenBy { it.key.second }.thenBy { it.key.third })
+            .take(50)
+            .map { (key, count) ->
+                "terrain=${formatTileId(key.first)} overlay=${formatTileId(key.second)} roadOrBridge=${formatTileId(key.third)} count=$count"
+            }
+        return renderSection("Tile combinations", counts.size, lines, 50)
+    }
+
+    @ClashScript
+    fun summarizeUnitStateBits2(save: Save): String {
+        return summarizeUnitField(
+            title = "Unit stateBits2",
+            values = save.locatedUnits().map { it.unit.stateBits2 },
+            formatter = { value -> value.toHex(2) }
+        )
+    }
+
+    @ClashScript
+    fun summarizeUnitStateFlags(save: Save): String {
+        return summarizeUnitField(
+            title = "Unit state flags",
+            values = save.locatedUnits().map { it.unit.stateFlags },
+            formatter = { value -> value.toHex(2) }
+        )
+    }
+
+    @ClashScript
+    fun summarizeUnitTypeCounts(save: Save): String {
+        val counts = save.locatedUnits().groupingBy { it.unit.typeId }.eachCount()
+        if (counts.isEmpty()) {
+            return "Unit type counts: none"
+        }
+
+        val lines = counts.entries
+            .sortedWith(compareByDescending<Map.Entry<Int, Int>> { it.value }.thenBy { it.key })
+            .map { (typeId, count) ->
+                val metadata = UnitTypes.metadata(typeId)
+                val label = metadata?.displayName ?: "unknown"
+                "type=$typeId name=$label count=$count"
+            }
+        return renderSection("Unit type counts", counts.size, lines, 50)
+    }
+
+    @ClashScript
+    fun summarizeWorldViewState(save: Save): String {
+        return buildString {
+            appendLine("World view state")
+            appendLine("saveName=\"${save.name}\"")
+            appendLine("mapSize=${save.mapWidthOrDefault()}x${save.mapHeightOrDefault()}")
+            appendLine("mapViewLeft=${save.mapViewLeft}")
+            appendLine("mapViewTop=${save.mapViewTop}")
+            appendLine("activeMissionIndex=${save.activeMissionIndex}")
+            appendLine("turnOwnerPlayerIndex=${save.turnOwnerPlayerIndex}")
+            appendLine("viewedPlayerIndex=${save.viewedPlayerIndex}")
+            appendLine("tiles=${save.tiles.size} armies=${save.armies.size} players=${save.players.size} castles=${save.castles.size}")
+        }.trimEnd()
     }
 
     private fun writeSaveData(save: Save): File {
@@ -98,27 +386,227 @@ object Scripts {
         result["byteIndex"] = index
         listIndex?.let { result["listIndex"] = it }
 
-        if (this is Tile && listIndex != null) {
-            result["mapIndex"] = listIndex
-            result["mapX"] = listIndex / 100
-            result["mapY"] = listIndex % 100
-            val tileName = TILE.values().firstOrNull { it.matches(this) }?.name
-            result["tileName"] = tileName
-        }
+        when (this) {
+            is Tile -> {
+                if (listIndex != null) {
+                    val (mapRow, mapColumn) = fromIndex(listIndex, (parent as? Save)?.mapWidthOrDefault() ?: 100)
+                    result["mapIndex"] = listIndex
+                    result["mapRow"] = mapRow
+                    result["mapColumn"] = mapColumn
+                }
+                result["terrainTileIdHex"] = terrainTileId.toHex(4)
+                result["overlayTileIdHex"] = overlayTileId.toHex(4)
+                result["roadOrBridgeTileIdHex"] = roadOrBridgeTileId.toHex(4)
+                result["hasOverlay"] = hasOverlay()
+                result["hasRoadOrBridge"] = hasRoadOrBridge()
+            }
 
-        if (this is Unit) {
-            UnitTypes.metadata(typeId)?.let { metadata ->
-                result["unitTypeName"] = metadata.displayName
-                result["unitLocalizedNames"] = metadata.localizedNames
-                result["unitSpriteFolder"] = metadata.folder
+            is Unit -> {
+                UnitTypes.metadata(typeId)?.let { metadata ->
+                    result["unitTypeName"] = metadata.displayName
+                    result["unitLocalizedNames"] = metadata.localizedNames
+                    result["unitSpriteFolder"] = metadata.folder
+                    result["unitCategories"] = metadata.categories.map { it.name.lowercase() }
+                }
+                result["stanceBitsHex"] = stanceBits.toHex(2)
+                result["stateFlagsHex"] = stateFlags.toHex(2)
+                result["stateBits2Hex"] = stateBits2.toHex(2)
+                result["auxRuntimeStateHex"] = auxRuntimeState.toHex(8)
+            }
+
+            is Army -> {
+                result["tileIndex"] = toIndex(tileRow, tileColumn, (parent as? Save)?.mapWidthOrDefault() ?: 100)
+                result["queuedPathWaypoints"] = queuedPathWaypoints().map { waypoint ->
+                    linkedMapOf(
+                        "tileRow" to waypoint.tileRow,
+                        "tileColumn" to waypoint.tileColumn,
+                        "cumulativeCost" to waypoint.cumulativeCost
+                    )
+                }
+            }
+
+            is Player -> {
+                result["revealedTileCount"] = revealedTilesBitset.sumOf { countBits(it) }
+                result["prisonerTransferQueueEntries"] = prisonerTransferQueueEntries().map { entry ->
+                    linkedMapOf<String, Any?>(
+                        "marker" to entry.marker,
+                        "isEmpty" to entry.isEmpty,
+                        "rawBytes" to entry.rawBytes.map { byte -> byte.toInt() }
+                    )
+                }
+            }
+
+            is Castle -> {
+                result["buildingNames"] = buildingNames()
+                result["garrisonOrders"] = garrisonOrders().map { order ->
+                    linkedMapOf<String, Any>(
+                        "rawValue" to order.rawValue,
+                        "trainCountdown" to order.trainCountdown,
+                        "repairCountdown" to order.repairCountdown
+                    )
+                }
+                result["prisonerSlots"] = prisonerSlots().map { slot ->
+                    linkedMapOf<String, Any>(
+                        "marker" to slot.marker,
+                        "rawBytes" to slot.rawBytes.map { byte -> byte.toInt() }
+                    )
+                }
             }
         }
 
-        if (this is Castle) {
-            result["buildingNames"] = buildingNames()
+        return result
+    }
+
+    private fun Save.locatedUnits(): List<LocatedUnit> {
+        val result = mutableListOf<LocatedUnit>()
+        armies.forEachIndexed { armyIndex, army ->
+            army.units.forEachIndexed { slotIndex, unit ->
+                result += LocatedUnit(
+                    location = "army#$armyIndex@(${army.tileRow},${army.tileColumn})",
+                    slotIndex = slotIndex,
+                    ownerPlayerIndex = army.ownerPlayerIndex,
+                    unit = unit
+                )
+            }
+        }
+        castles.forEachIndexed { castleIndex, castle ->
+            castle.units.forEachIndexed { slotIndex, unit ->
+                result += LocatedUnit(
+                    location = "castle#$castleIndex@(${castle.tileRow},${castle.tileColumn})",
+                    slotIndex = slotIndex,
+                    ownerPlayerIndex = castle.ownerPlayerIndex,
+                    unit = unit
+                )
+            }
+        }
+        return result
+    }
+
+    private fun Save.locatedTiles(): List<LocatedTile> {
+        val mapWidth = mapWidthOrDefault()
+        return tiles.mapIndexed { tileIndex, tile ->
+            val (tileRow, tileColumn) = fromIndex(tileIndex, mapWidth)
+            LocatedTile(tileIndex, tileRow, tileColumn, tile)
+        }
+    }
+
+    private fun Save.mapWidthOrDefault(): Int {
+        return mapWidthTiles.takeIf { it > 0 } ?: 100
+    }
+
+    private fun Save.mapHeightOrDefault(): Int {
+        return mapHeightTiles.takeIf { it > 0 } ?: 100
+    }
+
+    private fun summarizeTileField(title: String, ids: List<Int>): String {
+        val counts = ids.groupingBy { it }.eachCount()
+        if (counts.isEmpty()) {
+            return "$title: none"
+        }
+        val lines = counts.entries
+            .sortedWith(compareByDescending<Map.Entry<Int, Int>> { it.value }.thenBy { it.key })
+            .map { (tileId, count) -> "${formatTileId(tileId)} count=$count" }
+        return renderSection(title, counts.size, lines, 50)
+    }
+
+    private fun summarizeUnitField(title: String, values: List<Int>, formatter: (Int) -> String): String {
+        val counts = values.groupingBy { it }.eachCount()
+        if (counts.isEmpty()) {
+            return "$title: none"
+        }
+        val lines = counts.entries
+            .sortedWith(compareByDescending<Map.Entry<Int, Int>> { it.value }.thenBy { it.key })
+            .map { (value, count) -> "${formatter(value)} count=$count" }
+        return renderSection(title, counts.size, lines, 50)
+    }
+
+    private fun formatLocatedUnits(
+        title: String,
+        units: List<LocatedUnit>,
+        extraFormatter: (LocatedUnit) -> String = { "" }
+    ): String {
+        if (units.isEmpty()) {
+            return "$title: none"
+        }
+        val lines = units.take(DEFAULT_LIST_LIMIT).map { locatedUnit ->
+            val metadata = locatedUnit.metadata
+            val typeLabel = metadata?.displayName ?: "unknown"
+            buildString {
+                append(locatedUnit.location)
+                append(" slot=")
+                append(locatedUnit.slotIndex)
+                append(" owner=")
+                append(locatedUnit.ownerPlayerIndex)
+                append(" type=")
+                append(locatedUnit.unit.typeId)
+                append("/")
+                append(typeLabel)
+                append(" ap=")
+                append(locatedUnit.unit.currentActionPoints)
+                append(" hp=")
+                append(locatedUnit.unit.currentHealthPercent)
+                append(" fatigue=")
+                append(locatedUnit.unit.fatigue)
+                append(" morale=")
+                append(locatedUnit.unit.morale)
+                append(" stance=")
+                append(locatedUnit.unit.stanceBits.toHex(2))
+                val extra = extraFormatter(locatedUnit)
+                if (extra.isNotBlank()) {
+                    append(" ")
+                    append(extra)
+                }
+            }
+        }
+        return renderSection(title, units.size, lines)
+    }
+
+    private fun formatLocatedTiles(
+        title: String,
+        tiles: List<LocatedTile>,
+        formatter: (LocatedTile) -> String
+    ): String {
+        if (tiles.isEmpty()) {
+            return "$title: none"
         }
 
-        return result
+        val lines = tiles.take(DEFAULT_LIST_LIMIT).map { locatedTile ->
+            "tile#${locatedTile.index} row=${locatedTile.tileRow} column=${locatedTile.tileColumn} ${formatter(locatedTile)}"
+        }
+        return renderSection(title, tiles.size, lines)
+    }
+
+    private fun renderSection(title: String, totalCount: Int, lines: List<String>, limit: Int = DEFAULT_LIST_LIMIT): String {
+        val truncated = if (lines.size > limit) lines.take(limit) else lines
+        return buildString {
+            appendLine("$title ($totalCount)")
+            truncated.forEach { line ->
+                appendLine(line)
+            }
+            if (lines.size > limit) {
+                append("... ${lines.size - limit} more")
+            }
+        }.trimEnd()
+    }
+
+    private fun formatTileId(tileId: Int): String {
+        return if (tileId == 0xFFFF) {
+            "none"
+        } else {
+            "$tileId (${tileId.toHex(4)})"
+        }
+    }
+
+    private fun Int.toHex(width: Int): String {
+        return "0x" + this.toUInt().toString(16).uppercase().padStart(width, '0')
+    }
+
+    private fun List<Byte>.toUnsignedSummary(): String {
+        return joinToString(prefix = "[", postfix = "]") { byte -> (byte.toInt() and 0xFF).toString() }
+    }
+
+    private fun countBits(byte: Byte): Int {
+        return Integer.bitCount(byte.toInt() and 0xFF)
     }
 
     private fun Any?.asSerializableValue(): Any? = when (this) {
@@ -130,6 +618,7 @@ object Scripts {
                 else -> element
             }
         }
+
         else -> this
     }
 
@@ -159,6 +648,7 @@ object Scripts {
                 }
             }
         }
+
         is Iterable<*> -> {
             val list = this.toList()
             if (list.isEmpty()) {
@@ -179,6 +669,7 @@ object Scripts {
                 }
             }
         }
+
         else -> "\"${escapeJson(this.toString())}\""
     }
 
@@ -199,5 +690,22 @@ object Scripts {
 
     private fun StringBuilder.appendIndent(indentLevel: Int) {
         repeat(indentLevel) { append("  ") }
+    }
+
+    private data class LocatedTile(
+        val index: Int,
+        val tileRow: Int,
+        val tileColumn: Int,
+        val tile: Tile
+    )
+
+    private data class LocatedUnit(
+        val location: String,
+        val slotIndex: Int,
+        val ownerPlayerIndex: Int,
+        val unit: Unit
+    ) {
+        val metadata: UnitTypeMetadata?
+            get() = UnitTypes.metadata(unit.typeId)
     }
 }

--- a/src/com/lis/clash/table.kt
+++ b/src/com/lis/clash/table.kt
@@ -23,15 +23,32 @@ class DynamicTableModel(val _data: () -> List<ClashObject>, val dataClass: KClas
     }
 
     override fun getValueAt(row: Int, col: Int): Any? {
-        return getClassDescriptor(dataClass).getSimpleProperty(col).get(_data()[row])
+        return formatValue(getClassDescriptor(dataClass).getSimpleProperty(col).get(_data()[row]))
     }
 
     override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean {
-        return true
+        return getClassDescriptor(dataClass).getSimpleProperty(columnIndex).get(_data()[rowIndex]) !is List<*>
     }
 
     override fun setValueAt(aValue: Any, row: Int, col: Int) {
         return getClassDescriptor(dataClass).getSimpleProperty(col).setString(_data()[row], aValue as String)
+    }
+
+    private fun formatValue(value: Any?): Any? = when (value) {
+        is List<*> -> {
+            val preview = value.take(8).joinToString(",") { element ->
+                when (element) {
+                    is Byte -> element.toInt().toString()
+                    else -> element.toString()
+                }
+            }
+            if (value.size > 8) {
+                "[$preview,...] (len=${value.size})"
+            } else {
+                "[$preview]"
+            }
+        }
+        else -> value
     }
 }
 

--- a/src/com/lis/clash/types.kt
+++ b/src/com/lis/clash/types.kt
@@ -1,14 +1,23 @@
 package com.lis.clash
 
-import com.lis.clash.objects.Tile
+enum class UnitCategory {
+    FLYING,
+    CARGO,
+    SPECIAL_PERSONAGE
+}
 
 data class UnitTypeMetadata(
     val id: Int,
     val localizedNames: String,
-    val folder: String
+    val folder: String,
+    val categories: Set<UnitCategory> = emptySet()
 ) {
     val displayName: String
         get() = localizedNames.split(" / ").getOrNull(1) ?: localizedNames.split(" / ").first()
+
+    fun hasCategory(category: UnitCategory): Boolean {
+        return category in categories
+    }
 }
 
 object UnitTypes {
@@ -39,15 +48,15 @@ object UnitTypes {
         UnitTypeMetadata(23, "Szkielet / Skeleton", "szk"),
         UnitTypeMetadata(24, "Mag / Wizard", "mag"),
         UnitTypeMetadata(25, "Duch / Ghost", "duch"),
-        UnitTypeMetadata(26, "Orzeł / Eagle", "orzel"),
-        UnitTypeMetadata(27, "Pegaz / Pegasus", "pegaz"),
-        UnitTypeMetadata(28, "Skrzydlak / Winger", "skrz"),
-        UnitTypeMetadata(29, "Ważka / Fly / Riesenlibelle", "wazka"),
-        UnitTypeMetadata(30, "Smok / Dragon / Drachen", "smok"),
-        UnitTypeMetadata(31, "Złoto / Gold", "gold"),
-        UnitTypeMetadata(32, "Chłopi / Peasants", "peas"),
-        UnitTypeMetadata(33, "Dowódca / Tactician / Soldat", "specm"),
-        UnitTypeMetadata(34, "Dowódca / Tactician / Soldat", "speck")
+        UnitTypeMetadata(26, "Orzeł / Eagle", "orzel", setOf(UnitCategory.FLYING)),
+        UnitTypeMetadata(27, "Pegaz / Pegasus", "pegaz", setOf(UnitCategory.FLYING)),
+        UnitTypeMetadata(28, "Skrzydlak / Winger", "skrz", setOf(UnitCategory.FLYING)),
+        UnitTypeMetadata(29, "Ważka / Fly / Riesenlibelle", "wazka", setOf(UnitCategory.FLYING)),
+        UnitTypeMetadata(30, "Smok / Dragon / Drachen", "smok", setOf(UnitCategory.FLYING)),
+        UnitTypeMetadata(31, "Złoto / Gold", "gold", setOf(UnitCategory.CARGO)),
+        UnitTypeMetadata(32, "Chłopi / Peasants", "peas", setOf(UnitCategory.CARGO)),
+        UnitTypeMetadata(33, "Dowódca / Tactician / Soldat", "specm", setOf(UnitCategory.SPECIAL_PERSONAGE)),
+        UnitTypeMetadata(34, "Dowódca / Tactician / Soldat", "speck", setOf(UnitCategory.SPECIAL_PERSONAGE))
     )
 
     private val byId = all.associateBy(UnitTypeMetadata::id)
@@ -55,11 +64,28 @@ object UnitTypes {
     fun metadata(typeId: Int): UnitTypeMetadata? = byId[typeId]
 }
 
-enum class TILE(val type1: Byte, val type2: Byte) {
-    GRASS(0, 0),
-    TREASURE(-16, 2);
+data class QueuedPathWaypoint(
+    val tileRow: Int,
+    val tileColumn: Int,
+    val cumulativeCost: Int
+)
 
-    fun matches(tile: Tile): Boolean {
-        return tile.type1 == type1 && tile.type2 == type2
-    }
+data class RawSixByteRecord(
+    val rawBytes: List<Byte>
+) {
+    val marker: Int
+        get() = rawBytes.firstOrNull()?.toInt() ?: -1
+
+    val isEmpty: Boolean
+        get() = rawBytes.firstOrNull() == (-1).toByte()
+}
+
+data class GarrisonOrder(
+    val rawValue: Int
+) {
+    val trainCountdown: Int
+        get() = rawValue and 0x07
+
+    val repairCountdown: Int
+        get() = (rawValue ushr 3) and 0x07
 }

--- a/src/test/kotlin/com/lis/clash/SaveConsolidationTest.kt
+++ b/src/test/kotlin/com/lis/clash/SaveConsolidationTest.kt
@@ -16,20 +16,20 @@ class SaveConsolidationTest {
     }
 
     @Test
-    fun `editing fixed-length string preserves trailing bytes`() {
+    fun `editing fixed-length string zero pads trailing bytes`() {
         val base = MutableList(saveSize) { 42.toByte() }
         base[firstCastleOffset + 4] = 1
 
         val save = Save().withBytes<Save>(base)
-        save.castles.first().name = "AB"
+        save.castles.first().displayName = "AB"
 
         val edited = save.bytes
         assertEquals('A'.code.toByte(), edited[firstCastleOffset + 5])
         assertEquals('B'.code.toByte(), edited[firstCastleOffset + 6])
 
-        // Remaining bytes in the fixed-width field should stay unchanged.
+        // Remaining bytes in the fixed-width field should be zero padded.
         for (i in 7..14) {
-            assertEquals(42.toByte(), edited[firstCastleOffset + i])
+            assertEquals(0.toByte(), edited[firstCastleOffset + i])
         }
     }
 
@@ -105,6 +105,6 @@ class SaveConsolidationTest {
         val save = Save().withBytes<Save>(base)
 
         assertEquals(1, save.players.first().isActive)
-        assertEquals("Drebegen\u0000\u0000\u0000", save.players.first().displayName)
+        assertEquals("Drebegen", save.players.first().displayName)
     }
 }

--- a/src/test/kotlin/com/lis/clash/SaveFormatParsingTest.kt
+++ b/src/test/kotlin/com/lis/clash/SaveFormatParsingTest.kt
@@ -1,0 +1,219 @@
+package com.lis.clash
+
+import com.lis.clash.objects.Save
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.reflect.full.functions
+import kotlin.reflect.full.hasAnnotation
+
+class SaveFormatParsingTest {
+    @Test
+    fun parsesRecoveredSaveFields() {
+        val save = Save().withBytes<Save>(buildSyntheticSave().toList())
+
+        assertEquals("TEST SAVE", save.name)
+        assertEquals(60, save.mapWidthTiles)
+        assertEquals(40, save.mapHeightTiles)
+        assertEquals(7, save.mapViewLeft)
+        assertEquals(9, save.mapViewTop)
+        assertEquals(-1, save.activeMissionIndex)
+        assertEquals(2, save.turnOwnerPlayerIndex)
+        assertEquals(3, save.viewedPlayerIndex)
+
+        val tile = save.tiles.first()
+        assertEquals(321, tile.terrainTileId)
+        assertEquals(654, tile.overlayTileId)
+        assertEquals(872, tile.roadOrBridgeTileId)
+        assertTrue(tile.hasOverlay())
+        assertTrue(tile.hasRoadOrBridge())
+
+        val player = save.players.first()
+        assertEquals("Player One", player.displayName)
+        assertEquals(1, player.isActive)
+        assertEquals(2, player.queenRelationshipState)
+        assertEquals(5, player.queenPortraitIndex)
+        assertEquals(321, player.queenNextRelationshipCheckTurn)
+        assertEquals(listOf(9, 8, 7, 6, 5, 4), player.prisonerTransferQueueEntries().first().rawBytes.map { byte -> byte.toInt() })
+
+        val army = save.armies.single()
+        assertEquals(12, army.tileRow)
+        assertEquals(34, army.tileColumn)
+        assertEquals(1, army.ownerPlayerIndex)
+        assertEquals(6, army.facingDirection)
+        assertEquals(2, army.queuedPathWaypointCount)
+        assertEquals(1, army.isHiddenOnWorldMap)
+        assertEquals(
+            listOf(
+                QueuedPathWaypoint(12, 34, 5),
+                QueuedPathWaypoint(13, 36, 8)
+            ),
+            army.queuedPathWaypoints()
+        )
+
+        val unit = army.units.single()
+        assertEquals(34, unit.typeId)
+        assertEquals(1, unit.ownerPlayerIndex)
+        assertEquals(5, unit.currentActionPoints)
+        assertEquals(80, unit.currentHealthPercent)
+        assertEquals(90, unit.fatigue)
+        assertEquals(4, unit.morale)
+        assertEquals(0x12, unit.stanceBits)
+        assertEquals(0x0E, unit.stateFlags)
+        assertEquals(0x11223344, unit.auxRuntimeState)
+        assertEquals(0x03, unit.stateBits2)
+
+        val castle = save.castles.single()
+        assertEquals(44, castle.tileRow)
+        assertEquals(55, castle.tileColumn)
+        assertEquals(2, castle.ownerPlayerIndex)
+        assertEquals(3, castle.appearance)
+        assertEquals(4, castle.footprintClass)
+        assertEquals("CastleOne", castle.displayName)
+        assertEquals(0x1D, castle.garrisonOrders().first().rawValue)
+        assertEquals(5, castle.garrisonOrders().first().trainCountdown)
+        assertEquals(3, castle.garrisonOrders().first().repairCountdown)
+        assertEquals(listOf(1, 2, 3, 4, 5, 6), castle.prisonerSlots().first().rawBytes.map { byte -> byte.toInt() })
+    }
+
+    @Test
+    fun exposesExpandedDebugScriptSet() {
+        val scriptNames = Scripts::class.functions
+            .filter { it.hasAnnotation<ClashScript>() }
+            .map { it.name }
+            .toSet()
+
+        assertTrue(scriptNames.size >= 20)
+        assertTrue("summarizeTerrainTileIds" in scriptNames)
+        assertTrue("listQueuedArmyPaths" in scriptNames)
+        assertTrue("summarizeWorldViewState" in scriptNames)
+        assertTrue("listUnitsWithStateFlags" in scriptNames)
+    }
+
+    private fun buildSyntheticSave(): ByteArray {
+        val bytes = ByteArray(514360)
+
+        repeat(500) { armyIndex ->
+            writeLittleEndian(bytes, 147190 + armyIndex * 725 + 6, 0xFFFF, 2)
+        }
+        repeat(10) { castleIndex ->
+            writeLittleEndian(bytes, 509690 + castleIndex * 467 + 4, 0xFF, 1)
+        }
+
+        writeString(bytes, 0, 16, "TEST SAVE")
+
+        writeLittleEndian(bytes, 16, 321, 2)
+        writeLittleEndian(bytes, 18, 654, 2)
+        writeLittleEndian(bytes, 20, 872, 2)
+
+        writeLittleEndian(bytes, 140000, 60, 4)
+        writeLittleEndian(bytes, 140004, 40, 4)
+        writeLittleEndian(bytes, 140008, 7, 4)
+        writeLittleEndian(bytes, 140012, 9, 4)
+        writeLittleEndian(bytes, 140017, -1, 4)
+
+        writeLittleEndian(bytes, 147139, 2, 4)
+        writeLittleEndian(bytes, 147143, 3, 4)
+
+        val playerBase = 140040
+        writeLittleEndian(bytes, playerBase, 1, 4)
+        writeString(bytes, playerBase + 4, 11, "Player One")
+        writeLittleEndian(bytes, playerBase + 15, 11, 4)
+        writeLittleEndian(bytes, playerBase + 19, 22, 4)
+        writeLittleEndian(bytes, playerBase + 23, 1, 4)
+        writeLittleEndian(bytes, playerBase + 27, 2, 4)
+        writeLittleEndian(bytes, playerBase + 39, 1, 4)
+        writeLittleEndian(bytes, playerBase + 47, 4, 1)
+        writeLittleEndian(bytes, playerBase + 48, 3, 1)
+        writeLittleEndian(bytes, playerBase + 49, 1, 4)
+        writeLittleEndian(bytes, playerBase + 53, 2, 4)
+        bytes[playerBase + 57] = 0x0F
+        listOf(9, 8, 7, 6, 5, 4).forEachIndexed { index, value ->
+            writeLittleEndian(bytes, playerBase + 1357 + index, value, 1)
+        }
+        writeLittleEndian(bytes, playerBase + 1419, 2, 1)
+        writeLittleEndian(bytes, playerBase + 1420, 5, 1)
+        writeLittleEndian(bytes, playerBase + 1421, 321, 2)
+
+        val armyBase = 147190
+        repeat(10) { slotIndex ->
+            writeLittleEndian(bytes, armyBase + 6 + slotIndex * 31, 0xFFFF, 2)
+        }
+        writeLittleEndian(bytes, armyBase + 0, 12, 2)
+        writeLittleEndian(bytes, armyBase + 2, 34, 2)
+        writeLittleEndian(bytes, armyBase + 4, 1, 1)
+        writeLittleEndian(bytes, armyBase + 5, 6, 1)
+        writeLittleEndian(bytes, armyBase + 316, 2, 4)
+        writeLittleEndian(bytes, armyBase + 320, 12, 1)
+        writeLittleEndian(bytes, armyBase + 321, 34, 1)
+        writeLittleEndian(bytes, armyBase + 322, 5, 2)
+        writeLittleEndian(bytes, armyBase + 324, 13, 1)
+        writeLittleEndian(bytes, armyBase + 325, 36, 1)
+        writeLittleEndian(bytes, armyBase + 326, 8, 2)
+        writeLittleEndian(bytes, armyBase + 720, 1, 1)
+
+        val armyUnitBase = armyBase + 6
+        writeLittleEndian(bytes, armyUnitBase + 0, 34, 2)
+        writeLittleEndian(bytes, armyUnitBase + 2, 1, 1)
+        writeLittleEndian(bytes, armyUnitBase + 8, 5, 1)
+        writeLittleEndian(bytes, armyUnitBase + 9, 80, 1)
+        writeLittleEndian(bytes, armyUnitBase + 10, 90, 1)
+        writeLittleEndian(bytes, armyUnitBase + 11, 4, 1)
+        writeLittleEndian(bytes, armyUnitBase + 12, 0x12, 1)
+        writeLittleEndian(bytes, armyUnitBase + 13, 0x0E, 1)
+        writeLittleEndian(bytes, armyUnitBase + 18, 0x11223344, 4)
+        writeLittleEndian(bytes, armyUnitBase + 22, 0x03, 1)
+
+        val castleBase = 509690
+        repeat(12) { slotIndex ->
+            writeLittleEndian(bytes, castleBase + 18 + slotIndex * 31, 0xFFFF, 2)
+        }
+        writeLittleEndian(bytes, castleBase + 0, 44, 1)
+        writeLittleEndian(bytes, castleBase + 1, 55, 1)
+        writeLittleEndian(bytes, castleBase + 2, 2, 1)
+        writeLittleEndian(bytes, castleBase + 3, 3, 1)
+        writeLittleEndian(bytes, castleBase + 4, 4, 1)
+        writeString(bytes, castleBase + 5, 10, "CastleOne")
+        writeLittleEndian(bytes, castleBase + 18, 5, 2)
+        writeLittleEndian(bytes, castleBase + 20, 2, 1)
+        writeLittleEndian(bytes, castleBase + 26, 7, 1)
+        writeLittleEndian(bytes, castleBase + 27, 100, 1)
+        writeLittleEndian(bytes, castleBase + 28, 10, 1)
+        writeLittleEndian(bytes, castleBase + 29, 9, 1)
+        writeLittleEndian(bytes, castleBase + 30, 0x05, 1)
+        writeLittleEndian(bytes, castleBase + 31, 0x08, 1)
+        writeLittleEndian(bytes, castleBase + 36, 0x12345678.toInt(), 4)
+        writeLittleEndian(bytes, castleBase + 40, 0x01, 1)
+        writeLittleEndian(bytes, castleBase + 390, 0x1D, 1)
+        writeLittleEndian(bytes, castleBase + 414, -1, 1)
+        writeLittleEndian(bytes, castleBase + 416, 0x13, 1)
+        writeLittleEndian(bytes, castleBase + 420, 0x01, 1)
+        writeLittleEndian(bytes, castleBase + 421, 9, 1)
+        writeLittleEndian(bytes, castleBase + 429, 4, 1)
+        writeLittleEndian(bytes, castleBase + 430, 245, 2)
+        writeLittleEndian(bytes, castleBase + 434, 77, 1)
+        writeLittleEndian(bytes, castleBase + 435, 3, 1)
+        writeLittleEndian(bytes, castleBase + 436, 12, 1)
+        writeLittleEndian(bytes, castleBase + 438, 54321, 4)
+        writeLittleEndian(bytes, castleBase + 444, 5, 1)
+        listOf(1, 2, 3, 4, 5, 6).forEachIndexed { index, value ->
+            writeLittleEndian(bytes, castleBase + 445 + index, value, 1)
+        }
+        writeLittleEndian(bytes, castleBase + 463, 77, 4)
+
+        return bytes
+    }
+
+    private fun writeString(bytes: ByteArray, offset: Int, length: Int, value: String) {
+        val encoded = value.encodeToByteArray()
+        repeat(length) { index ->
+            bytes[offset + index] = encoded.getOrElse(index) { 0 }
+        }
+    }
+
+    private fun writeLittleEndian(bytes: ByteArray, offset: Int, value: Int, length: Int) {
+        writeLittleEndianInt(value, length).forEachIndexed { index, byte ->
+            bytes[offset + index] = byte
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- replaced the old guessed tile and unit-slot layouts with recovered `terrain/overlay/road_or_bridge` tile words plus signed 16-bit unit type ids, aux runtime state, and secondary state bits
- expanded the editor model with recovered world-view, army, player, and castle fields including queued path counts, hidden-stack state, queen state, garrison order bytes, prisoner buffers, and add-on/building metadata
- updated the Swing UI to render tiles from the recovered format, sync map clicks with tile-table selection, highlight the selected tile, summarize long byte-array columns, and sort the script list
- replaced stale tile scripts with an expanded debugging script set covering terrain ids, overlays, roads, army paths, unit state flags, cargo/flying/special units, exploration, castle add-ons, and prisoner queues
- added regression tests for the recovered offsets and updated the consolidated save-format documentation
- kept the fat-JAR packaging fix so the instrumented Swing form classes are used when building the app bundle

## Why it was changed
The editor still exposed several outdated save-format guesses even after the earlier `clash-disassembly` integration. This pass moves the UI and export/debug tooling onto the higher-confidence recovered structures so the editor can inspect and edit more of the real save layout without relying on stale byte guesses.

## Validation performed
- ran `GRADLE_USER_HOME=/home/andrz/git/clash-save-editor/.gradle-home ./gradlew test`
- ran `GRADLE_USER_HOME=/home/andrz/git/clash-save-editor/.gradle-home ./gradlew fatJar`
- launched the UI with `java -cp build/libs/clash-save-editor-1.0-SNAPSHOT-all.jar:...forms_rt.jar:...kotlin-reflect-1.6.10.jar com.lis.clash.ClashKt`

## Known limitations / follow-up work
- tile ids are now parsed correctly, but the semantic terrain-name mapping is still unresolved, so the map view uses deterministic debug coloring rather than exact terrain labels
- queued army paths, prisoner buffers, and castle prisoner slots are only partially decoded; the editor exposes their recovered layout and useful summaries, but not every subfield meaning is known yet
- Gradle still reports the pre-existing IntelliJ plugin configuration warnings about Java 9 vs IntelliJ 2023.1 and Kotlin stdlib handling