### PR TITLE
Fix runnable save editor jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,11 +9,13 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
+    maven("https://www.jetbrains.com/intellij-repository/releases/")
 }
 
 dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
+    runtimeOnly("com.jetbrains.intellij.java:java-gui-forms-rt:231.8109.175")
     testImplementation(kotlin("test-junit5"))
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.2")
@@ -28,11 +30,6 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }
-
-kotlin {
-    jvmToolchain(17)
-}
-
 
 sourceSets {
     main {


### PR DESCRIPTION
## Summary
- include the IntelliJ UI Designer runtime in the fat jar runtime classpath
- use the installed JDK while keeping Java 17 source/target bytecode

## Verification
- Previously ran `./gradlew.bat fatJar` successfully and launched the Swing editor window.
- Current session cannot rerun Gradle because network access is blocked for wrapper download.