### PR TITLE
[codex] Add MCP save tooling and recovered save semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,23 @@ java -jar build/libs/clash-save-editor-all.jar
 
 The build uses IntelliJ form instrumentation so `.form` UI files are compiled
 automatically.
+
+## MCP server
+
+The project also includes a stdio MCP server for LLM-assisted inspection and
+editing of Clash save files. During development, run it with:
+
+```bash
+./gradlew runMcpServer
+```
+
+After building the fat JAR, configure an MCP client to launch:
+
+```bash
+java -cp build/libs/clash-save-editor-all.jar com.lis.clash.mcp.ClashSaveMcpServerKt
+```
+
+The server exposes tools for schema discovery, save overviews, parsed object
+reads, raw byte reads, annotated property edits, and explicit raw byte writes.
+Structured edits require `outputPath` unless `inPlace=true`; in-place writes
+create a `.bak` file by default.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,14 @@ tasks.withType<JavaCompile> {
     targetCompatibility = "17"
 }
 
+tasks.register<JavaExec>("runMcpServer") {
+    group = "application"
+    description = "Run the Clash save MCP server over stdio."
+    classpath = sourceSets.main.get().runtimeClasspath
+    mainClass.set("com.lis.clash.mcp.ClashSaveMcpServerKt")
+    standardInput = System.`in`
+}
+
 val fatJar = tasks.register<Jar>("fatJar") {
     dependsOn(tasks.named("instrumentCode"))
     dependsOn(tasks.named("processResources"))

--- a/docs/reverse-engineering/clash-disassembly-evidence.md
+++ b/docs/reverse-engineering/clash-disassembly-evidence.md
@@ -1,0 +1,24 @@
+# clash-disassembly evidence notes
+
+These notes summarize high-confidence facts promoted from
+`../clash-disassembly/clash.c`.
+
+## Unit record
+- Unit creation initializes `currentActionPoints` from the unit-type table, sets health to `100`, sets fatigue to `0`, and clears the known state bits.
+- Unit health is clamped to `0..100`, fatigue to `0..100`, and morale to `0..20`.
+- Unit byte `+12` low bits `0..1` are the experience level. Values are `0..3`; `3` is the maximum tier.
+- Unit byte `+12` bits `2..3` are experience progress. The game increments progress and rolls it into the experience level when progress exceeds its local threshold.
+- Unit byte `+13` bit `2` is used by low-morale checks. Positive morale changes clear this bit.
+- Unit types `31..34` are skipped by morale and fatigue adjustment helpers.
+
+## Tile record
+- Overlay IDs `728..739` are temple/shrine overlays.
+- Terrain IDs `752` and `755` are buried treasure tiles. Digging treasure rewrites `752` to `0` and `755` to `4`.
+
+## Castle record
+- Castle add-on ids decode as `0` Court, `1` Tower, `2` Hospital, `3` Barracks, `4` Workshop, `5` School, `6` Smiths, `7` Peasants, `8` Barracks, and `255` empty.
+- The original castle name pool contains generated names such as `cantown`, `stone bell`, `hopenberg`, `timbran`, and `Keep`. The save stores the actual selected name in the castle record.
+
+## Deferred
+- The unit-type table contains more combat and movement fields, but Hex-Rays split the 88-byte records into sparse symbols. The current editor exposes formulas and fields only where the semantics are clear from code use.
+- Several unit state bits are copied and tested by combat/pathing code, but only the low-morale flag has been promoted to a named editable property.

--- a/docs/reverse-engineering/final-status.md
+++ b/docs/reverse-engineering/final-status.md
@@ -7,6 +7,10 @@
 - Replaced the old guessed `Unit` runtime fields with recovered `typeId`, `ownerPlayerIndex`, `currentActionPoints`, `currentHealthPercent`, `fatigue`, `morale`, `stanceBits`, and `stateFlags`.
 - Expanded `Castle` parsing to include add-on ids, construction lock, wall strength, upgrade timer, masked peasant/tax/plague fields, stored money, tech bits, and fact id.
 - Castle building bit flags exposed as: hospital, barracks, workshop, school, smiths.
+- Castle add-on slot ids now decode to recovered display names, including Court, Tower, Hospital, Barracks, Workshop, School, Smiths, and Peasants.
+- Unit experience and low-morale bits are exposed as masked fields that preserve unrelated state bits.
+- Temple/shrine overlays and buried treasure terrain ids are exposed through tile helpers and scripts.
+- Corrected shared world-view offsets to `140016..140032` and player-view fields to `147155`/`147159`.
 - Fixed-width integer fields now round-trip as little-endian values, and masked bitfields preserve unrelated bits.
 - Save exports now include recovered unit roster names and sprite folders from `clash-disassembly`.
 - Conservative field-window serialization for known fields.

--- a/docs/reverse-engineering/save-format.md
+++ b/docs/reverse-engineering/save-format.md
@@ -5,7 +5,7 @@
 |---|---:|---:|---:|---|
 | Save name | 0 | 1 | 16 | High |
 | Tiles | 16 | 10000 | 14 | High |
-| Shared world view state | 140000 | 1 | 7147 | High for listed fields |
+| Shared world view state | 140016 | 1 | 24 | High for listed fields |
 | Players | 140040 | 5 | 1423 | High |
 | Armies | 147190 | 500 | 725 | High |
 | Castles | 509690 | 10 | 467 | High |
@@ -22,15 +22,20 @@ Known fields:
 
 Other bytes are currently unknown/reserved (Low).
 
+Known overlay interpretation:
+- Overlay IDs `728..739` are temple/shrine tiles according to the original game data checks. The helper exposes `templeVariant` as `(overlayTileId - 728) / 2`.
+- Odd temple/shrine overlay IDs are currently exposed as `templeVisitedOrEmpty=true`, based on the game incrementing the overlay after temple entry.
+- Terrain IDs `752` and `755` are buried treasure tiles. Digging converts `752` to `0` and `755` to `4`.
+
 ### Shared world view state
 Known fields:
-- `mapWidthTiles` at +140000, length 4 (High)
-- `mapHeightTiles` at +140004, length 4 (High)
-- `mapViewLeft` at +140008, length 4 (High)
-- `mapViewTop` at +140012, length 4 (High)
-- `activeMissionIndex` at +140017, length 4 (High)
-- `turnOwnerPlayerIndex` at +147139, length 4 (High)
-- `viewedPlayerIndex` at +147143, length 4 (High)
+- `mapWidthTiles` at +140016, length 4 (High)
+- `mapHeightTiles` at +140020, length 4 (High)
+- `mapViewLeft` at +140024, length 4 (High)
+- `mapViewTop` at +140028, length 4 (High)
+- `activeMissionIndex` at +140032, length 4 (High)
+- `turnOwnerPlayerIndex` at +147155, length 4 (Medium/High)
+- `viewedPlayerIndex` at +147159, length 4 (Medium/High)
 
 ### Player (1423 bytes)
 Known fields:
@@ -73,10 +78,19 @@ Known fields:
 - `currentHealthPercent` +9 (High)
 - `fatigue` +10 (High)
 - `morale` +11 (High)
-- `stanceBits` +12 (Medium/High)
+- `stanceBits` +12, full raw byte containing experience plus other state bits (Medium/High)
+- `experienceLevel` +12, low 2 bits, values 0..3 where 3 is maximum/full experience (High for mask)
+- `experienceProgress` +12, bits 2..3, values 0..3; the game rolls this into `experienceLevel` (High for mask)
 - `stateFlags` +13 (Medium/High)
+- `lowMoraleFlag` +13, bit 2, set by low morale checks and cleared by positive morale changes (High for mask)
 - `auxRuntimeState` +18, length 4 (High for layout)
 - `stateBits2` +22, length 1 (High for layout)
+
+Observed constraints:
+- `currentHealthPercent` is clamped to `0..100`.
+- `fatigue` is clamped to `0..100`.
+- `morale` is clamped to `0..20`.
+- Unit types `31..34` are skipped by morale/fatigue adjustment helpers.
 
 Remaining bytes unknown/reserved (Low).
 
@@ -104,5 +118,17 @@ Known fields:
 - `techLevelBits` +444, low 3 bits (High)
 - `prisonerSlotsRaw` +445, length 18 (High for layout)
 - `castleFactId` +463, length 4 (High)
+
+Known `addonTypeIds`:
+- `0` Court
+- `1` Tower
+- `2` Hospital
+- `3` Barracks
+- `4` Workshop
+- `5` School
+- `6` Smiths
+- `7` Peasants
+- `8` Barracks
+- `255` Empty slot
 
 Remaining bytes unknown/reserved (Low).

--- a/src/com/lis/clash/map.kt
+++ b/src/com/lis/clash/map.kt
@@ -1,5 +1,6 @@
 package com.lis.clash
 
+import com.lis.clash.objects.Save
 import com.lis.clash.objects.Tile
 import java.awt.Color
 import java.awt.Dimension
@@ -8,12 +9,144 @@ import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
 
-fun toIndex(tileRow: Int, tileColumn: Int, mapWidth: Int = 100): Int {
-    return tileRow * mapWidth + tileColumn
+const val DEFAULT_MAP_WIDTH = 100
+const val DEFAULT_TILE_SIZE = 5
+const val EMPTY_TILE_ID = 0xFFFF
+
+val EMPTY_TILE_COLOR: Color = Color(24, 24, 24)
+
+fun toIndex(tileRow: Int, tileColumn: Int, mapWidth: Int = DEFAULT_MAP_WIDTH): Int {
+    val width = mapWidth.takeIf { it > 0 } ?: DEFAULT_MAP_WIDTH
+    return tileRow * width + tileColumn
 }
 
-fun fromIndex(index: Int, mapWidth: Int = 100): Pair<Int, Int> {
-    return index / mapWidth to index % mapWidth
+fun fromIndex(index: Int, mapWidth: Int = DEFAULT_MAP_WIDTH): Pair<Int, Int> {
+    val width = mapWidth.takeIf { it > 0 } ?: DEFAULT_MAP_WIDTH
+    return index / width to index % width
+}
+
+fun tileIndexAt(
+    pixelX: Int,
+    pixelY: Int,
+    tileSize: Int,
+    mapWidth: Int,
+    mapHeight: Int,
+    tileCount: Int
+): Int? {
+    if (pixelX < 0 || pixelY < 0 || tileSize <= 0 || mapWidth <= 0 || mapHeight <= 0) {
+        return null
+    }
+
+    val tileColumn = pixelX / tileSize
+    val tileRow = pixelY / tileSize
+    if (tileRow !in 0 until mapHeight || tileColumn !in 0 until mapWidth) {
+        return null
+    }
+
+    val tileIndex = toIndex(tileRow, tileColumn, mapWidth)
+    return tileIndex.takeIf { it in 0 until tileCount }
+}
+
+enum class MapMarkerType {
+    ARMY,
+    CASTLE
+}
+
+data class MapObjectMarker(
+    val type: MapMarkerType,
+    val tileRow: Int,
+    val tileColumn: Int,
+    val ownerPlayerIndex: Int,
+    val label: String,
+    val hidden: Boolean = false
+)
+
+data class MapRenderModel(
+    val mapWidth: Int,
+    val mapHeight: Int,
+    val tiles: List<Tile>,
+    val selectedTileIndex: Int = -1,
+    val armies: List<MapObjectMarker> = emptyList(),
+    val castles: List<MapObjectMarker> = emptyList()
+) {
+    fun markersAt(tileRow: Int, tileColumn: Int): List<MapObjectMarker> {
+        return (armies + castles).filter { it.tileRow == tileRow && it.tileColumn == tileColumn }
+    }
+}
+
+fun buildMapRenderModel(save: Save, selectedTileIndex: Int = -1): MapRenderModel {
+    val width = resolvedMapWidth(save.mapWidthTiles)
+    val height = resolvedMapHeight(save.mapHeightTiles, width, save.tiles.size)
+    val selected = selectedTileIndex.takeIf { it in save.tiles.indices } ?: -1
+
+    val armies = save.armies.mapIndexedNotNull { index, army ->
+        if (army.tileRow !in 0 until height || army.tileColumn !in 0 until width) {
+            return@mapIndexedNotNull null
+        }
+
+        MapObjectMarker(
+            type = MapMarkerType.ARMY,
+            tileRow = army.tileRow,
+            tileColumn = army.tileColumn,
+            ownerPlayerIndex = army.ownerPlayerIndex,
+            label = "Army $index",
+            hidden = army.isHiddenOnWorldMap != 0
+        )
+    }
+
+    val castles = save.castles.mapIndexedNotNull { index, castle ->
+        if (castle.tileRow !in 0 until height || castle.tileColumn !in 0 until width) {
+            return@mapIndexedNotNull null
+        }
+
+        MapObjectMarker(
+            type = MapMarkerType.CASTLE,
+            tileRow = castle.tileRow,
+            tileColumn = castle.tileColumn,
+            ownerPlayerIndex = castle.ownerPlayerIndex,
+            label = castle.displayName.ifBlank { "Castle $index" }
+        )
+    }
+
+    return MapRenderModel(
+        mapWidth = width,
+        mapHeight = height,
+        tiles = save.tiles,
+        selectedTileIndex = selected,
+        armies = armies,
+        castles = castles
+    )
+}
+
+fun resolvedMapWidth(rawMapWidth: Int): Int {
+    return rawMapWidth.takeIf { it > 0 } ?: DEFAULT_MAP_WIDTH
+}
+
+fun resolvedMapHeight(rawMapHeight: Int, mapWidth: Int, tileCount: Int): Int {
+    if (rawMapHeight > 0) {
+        return rawMapHeight
+    }
+
+    val width = resolvedMapWidth(mapWidth)
+    return if (tileCount == 0) 1 else (tileCount + width - 1) / width
+}
+
+fun terrainColorFor(terrainTileId: Int): Color {
+    if (terrainTileId == EMPTY_TILE_ID) {
+        return EMPTY_TILE_COLOR
+    }
+
+    val palette = listOf(
+        Color(68, 121, 63),
+        Color(92, 145, 74),
+        Color(139, 130, 81),
+        Color(74, 112, 132),
+        Color(123, 108, 86),
+        Color(98, 122, 101),
+        Color(151, 148, 112),
+        Color(84, 95, 74)
+    )
+    return palette[Math.floorMod(terrainTileId / 32, palette.size)]
 }
 
 

--- a/src/com/lis/clash/mcp/ClashSaveMcpServer.kt
+++ b/src/com/lis/clash/mcp/ClashSaveMcpServer.kt
@@ -1,0 +1,162 @@
+package com.lis.clash.mcp
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+
+internal class McpStdioServer(
+    private val saveTools: SaveMcpTools = SaveMcpTools()
+) {
+    private val supportedProtocolVersions = listOf(
+        "2025-11-25",
+        "2025-06-18",
+        "2025-03-26",
+        "2024-11-05"
+    )
+
+    fun serve(
+        input: BufferedReader = BufferedReader(InputStreamReader(System.`in`, Charsets.UTF_8)),
+        output: PrintWriter = PrintWriter(OutputStreamWriter(System.out, Charsets.UTF_8), true)
+    ) {
+        while (true) {
+            val line = input.readLine() ?: return
+            val response = handleMessage(line)
+            if (response != null) {
+                output.println(response)
+                output.flush()
+            }
+        }
+    }
+
+    fun handleMessage(line: String): String? {
+        val message = try {
+            Json.parse(line)
+        } catch (exception: Exception) {
+            return Json.stringify(errorResponse(null, -32700, "Parse error: ${exception.message}"))
+        }
+
+        if (message !is Map<*, *>) {
+            return Json.stringify(errorResponse(null, -32600, "Invalid Request"))
+        }
+
+        val id = message["id"]
+        val method = message["method"] as? String
+        if (method == null) {
+            return Json.stringify(errorResponse(id, -32600, "Invalid Request"))
+        }
+
+        // Notifications have no id and must not receive a JSON-RPC response.
+        if (!message.containsKey("id")) {
+            return null
+        }
+
+        return try {
+            Json.stringify(successResponse(id, handleRequest(method, message["params"])))
+        } catch (exception: ProtocolException) {
+            Json.stringify(errorResponse(id, exception.code, exception.message ?: "Protocol error"))
+        } catch (exception: Exception) {
+            Json.stringify(errorResponse(id, -32603, exception.message ?: "internal error"))
+        }
+    }
+
+    private fun handleRequest(method: String, params: Any?): Map<String, Any?> {
+        return when (method) {
+            "initialize" -> initialize(params)
+            "ping" -> linkedMapOf()
+            "tools/list" -> linkedMapOf(
+                "tools" to saveTools.listTools().map { it.toProtocolMap() }
+            )
+            "tools/call" -> callTool(params)
+            else -> throw ProtocolException(-32601, "Method not found: $method")
+        }
+    }
+
+    private fun initialize(params: Any?): Map<String, Any?> {
+        val protocolVersion = (params as? Map<*, *>)?.get("protocolVersion") as? String
+        val negotiatedVersion = protocolVersion
+            ?.takeIf { it in supportedProtocolVersions }
+            ?: supportedProtocolVersions.first()
+
+        return linkedMapOf(
+            "protocolVersion" to negotiatedVersion,
+            "capabilities" to linkedMapOf(
+                "tools" to linkedMapOf(
+                    "listChanged" to false
+                )
+            ),
+            "serverInfo" to linkedMapOf(
+                "name" to "clash-save-editor",
+                "version" to "1.0-SNAPSHOT"
+            ),
+            "instructions" to "Use save_get_schema first, then inspect save files with save_get_overview, save_list_entities, save_read_object, and save_read_bytes. Use save_set_property or save_write_bytes for intentional modifications."
+        )
+    }
+
+    private fun callTool(params: Any?): Map<String, Any?> {
+        val paramsMap = params.asStringKeyMap("params")
+        val name = paramsMap["name"] as? String
+            ?: throw ProtocolException(-32602, "tools/call requires string param 'name'.")
+        val arguments = when (val value = paramsMap["arguments"]) {
+            null -> emptyMap()
+            else -> value.asStringKeyMap("arguments")
+        }
+
+        val result = saveTools.call(name, arguments)
+        val protocolResult = linkedMapOf<String, Any?>(
+            "content" to listOf(
+                linkedMapOf(
+                    "type" to "text",
+                    "text" to result.text
+                )
+            ),
+            "structuredContent" to result.structuredContent
+        )
+        if (result.isError) {
+            protocolResult["isError"] = true
+        }
+        return protocolResult
+    }
+
+    private fun successResponse(id: Any?, result: Map<String, Any?>): Map<String, Any?> {
+        return linkedMapOf(
+            "jsonrpc" to "2.0",
+            "id" to id,
+            "result" to result
+        )
+    }
+
+    private fun errorResponse(id: Any?, code: Int, message: String): Map<String, Any?> {
+        return linkedMapOf(
+            "jsonrpc" to "2.0",
+            "id" to id,
+            "error" to linkedMapOf(
+                "code" to code,
+                "message" to message
+            )
+        )
+    }
+
+    private fun Any?.asStringKeyMap(name: String): Map<String, Any?> {
+        if (this !is Map<*, *>) {
+            throw ProtocolException(-32602, "$name must be an object.")
+        }
+        val result = linkedMapOf<String, Any?>()
+        for ((key, value) in this) {
+            if (key !is String) {
+                throw ProtocolException(-32602, "$name contains a non-string key.")
+            }
+            result[key] = value
+        }
+        return result
+    }
+
+    private class ProtocolException(
+        val code: Int,
+        override val message: String
+    ) : RuntimeException(message)
+}
+
+fun main() {
+    McpStdioServer().serve()
+}

--- a/src/com/lis/clash/mcp/Json.kt
+++ b/src/com/lis/clash/mcp/Json.kt
@@ -1,0 +1,263 @@
+package com.lis.clash.mcp
+
+internal object Json {
+    fun parse(input: String): Any? {
+        return Parser(input).parse()
+    }
+
+    fun stringify(value: Any?): String {
+        return when (value) {
+            null -> "null"
+            is String -> quote(value)
+            is Boolean -> value.toString()
+            is Number -> stringifyNumber(value)
+            is Map<*, *> -> value.entries.joinToString(prefix = "{", postfix = "}") { entry ->
+                val key = entry.key?.toString() ?: error("JSON object keys must not be null")
+                "${quote(key)}:${stringify(entry.value)}"
+            }
+
+            is Iterable<*> -> value.joinToString(prefix = "[", postfix = "]") { stringify(it) }
+            is Array<*> -> value.joinToString(prefix = "[", postfix = "]") { stringify(it) }
+            else -> quote(value.toString())
+        }
+    }
+
+    private fun stringifyNumber(value: Number): String {
+        return when (value) {
+            is Double -> {
+                require(value.isFinite()) { "JSON numbers must be finite" }
+                value.toString()
+            }
+
+            is Float -> {
+                require(value.isFinite()) { "JSON numbers must be finite" }
+                value.toString()
+            }
+
+            else -> value.toString()
+        }
+    }
+
+    private fun quote(value: String): String {
+        val builder = StringBuilder(value.length + 2)
+        builder.append('"')
+        value.forEach { char ->
+            when (char) {
+                '"' -> builder.append("\\\"")
+                '\\' -> builder.append("\\\\")
+                '\b' -> builder.append("\\b")
+                '\u000C' -> builder.append("\\f")
+                '\n' -> builder.append("\\n")
+                '\r' -> builder.append("\\r")
+                '\t' -> builder.append("\\t")
+                else -> {
+                    if (char.code < 0x20) {
+                        builder.append("\\u")
+                        builder.append(char.code.toString(16).padStart(4, '0'))
+                    } else {
+                        builder.append(char)
+                    }
+                }
+            }
+        }
+        builder.append('"')
+        return builder.toString()
+    }
+
+    private class Parser(private val input: String) {
+        private var index = 0
+
+        fun parse(): Any? {
+            val value = parseValue()
+            skipWhitespace()
+            if (index != input.length) {
+                fail("Unexpected trailing content")
+            }
+            return value
+        }
+
+        private fun parseValue(): Any? {
+            skipWhitespace()
+            if (index >= input.length) {
+                fail("Unexpected end of JSON")
+            }
+
+            return when (val char = input[index]) {
+                '{' -> parseObject()
+                '[' -> parseArray()
+                '"' -> parseString()
+                't' -> parseLiteral("true", true)
+                'f' -> parseLiteral("false", false)
+                'n' -> parseLiteral("null", null)
+                '-', in '0'..'9' -> parseNumber()
+                else -> fail("Unexpected character '$char'")
+            }
+        }
+
+        private fun parseObject(): Map<String, Any?> {
+            expect('{')
+            skipWhitespace()
+            val result = linkedMapOf<String, Any?>()
+            if (consume('}')) {
+                return result
+            }
+
+            while (true) {
+                skipWhitespace()
+                if (peek() != '"') {
+                    fail("Expected object key")
+                }
+                val key = parseString()
+                skipWhitespace()
+                expect(':')
+                result[key] = parseValue()
+                skipWhitespace()
+                if (consume('}')) {
+                    return result
+                }
+                expect(',')
+            }
+        }
+
+        private fun parseArray(): List<Any?> {
+            expect('[')
+            skipWhitespace()
+            val result = mutableListOf<Any?>()
+            if (consume(']')) {
+                return result
+            }
+
+            while (true) {
+                result += parseValue()
+                skipWhitespace()
+                if (consume(']')) {
+                    return result
+                }
+                expect(',')
+            }
+        }
+
+        private fun parseString(): String {
+            expect('"')
+            val builder = StringBuilder()
+            while (index < input.length) {
+                val char = input[index++]
+                when (char) {
+                    '"' -> return builder.toString()
+                    '\\' -> builder.append(parseEscape())
+                    else -> {
+                        if (char.code < 0x20) {
+                            fail("Unescaped control character in string")
+                        }
+                        builder.append(char)
+                    }
+                }
+            }
+            fail("Unterminated string")
+        }
+
+        private fun parseEscape(): Char {
+            if (index >= input.length) {
+                fail("Unterminated escape sequence")
+            }
+            return when (val escaped = input[index++]) {
+                '"' -> '"'
+                '\\' -> '\\'
+                '/' -> '/'
+                'b' -> '\b'
+                'f' -> '\u000C'
+                'n' -> '\n'
+                'r' -> '\r'
+                't' -> '\t'
+                'u' -> parseUnicodeEscape()
+                else -> fail("Unsupported escape sequence \\$escaped")
+            }
+        }
+
+        private fun parseUnicodeEscape(): Char {
+            if (index + 4 > input.length) {
+                fail("Incomplete unicode escape")
+            }
+            val hex = input.substring(index, index + 4)
+            if (!hex.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }) {
+                fail("Invalid unicode escape")
+            }
+            index += 4
+            return hex.toInt(16).toChar()
+        }
+
+        private fun parseLiteral(text: String, value: Any?): Any? {
+            if (!input.startsWith(text, index)) {
+                fail("Expected $text")
+            }
+            index += text.length
+            return value
+        }
+
+        private fun parseNumber(): Number {
+            val start = index
+            consume('-')
+            if (consume('0')) {
+                // Leading zero is only valid for the single zero digit.
+            } else {
+                readDigits()
+            }
+
+            var floatingPoint = false
+            if (consume('.')) {
+                floatingPoint = true
+                readDigits()
+            }
+            if (consume('e') || consume('E')) {
+                floatingPoint = true
+                consume('+') || consume('-')
+                readDigits()
+            }
+
+            val text = input.substring(start, index)
+            return if (floatingPoint) {
+                text.toDoubleOrNull() ?: fail("Invalid number")
+            } else {
+                text.toLongOrNull() ?: fail("Invalid number")
+            }
+        }
+
+        private fun readDigits() {
+            val start = index
+            while (index < input.length && input[index] in '0'..'9') {
+                index++
+            }
+            if (start == index) {
+                fail("Expected digit")
+            }
+        }
+
+        private fun skipWhitespace() {
+            while (index < input.length && input[index] in listOf(' ', '\t', '\r', '\n')) {
+                index++
+            }
+        }
+
+        private fun peek(): Char? {
+            return input.getOrNull(index)
+        }
+
+        private fun expect(char: Char) {
+            if (!consume(char)) {
+                fail("Expected '$char'")
+            }
+        }
+
+        private fun consume(char: Char): Boolean {
+            if (input.getOrNull(index) == char) {
+                index++
+                return true
+            }
+            return false
+        }
+
+        private fun fail(message: String): Nothing {
+            throw IllegalArgumentException("$message at character $index")
+        }
+    }
+}

--- a/src/com/lis/clash/mcp/SaveMcpTools.kt
+++ b/src/com/lis/clash/mcp/SaveMcpTools.kt
@@ -1,0 +1,1089 @@
+package com.lis.clash.mcp
+
+import com.lis.clash.AggregatePropertyDescriptor
+import com.lis.clash.ClashPropertyDescriptor
+import com.lis.clash.MaskedPropertyDescriptor
+import com.lis.clash.SignedPropertyDescriptor
+import com.lis.clash.UnitTypes
+import com.lis.clash.fromIndex
+import com.lis.clash.getClassDescriptor
+import com.lis.clash.objects.Army
+import com.lis.clash.objects.Castle
+import com.lis.clash.objects.ClashObject
+import com.lis.clash.objects.Player
+import com.lis.clash.objects.Save
+import com.lis.clash.objects.Tile
+import com.lis.clash.objects.Unit as ClashUnit
+import java.io.File
+import kotlin.math.min
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.jvmErasure
+
+internal const val MINIMUM_REPRESENTED_SAVE_SIZE = 514360
+
+internal data class ToolDefinition(
+    val name: String,
+    val title: String,
+    val description: String,
+    val inputSchema: Map<String, Any?>
+) {
+    fun toProtocolMap(): Map<String, Any?> {
+        return linkedMapOf(
+            "name" to name,
+            "title" to title,
+            "description" to description,
+            "inputSchema" to inputSchema
+        )
+    }
+}
+
+internal data class ToolCallResult(
+    val structuredContent: Any?,
+    val text: String = Json.stringify(structuredContent),
+    val isError: Boolean = false
+)
+
+internal class ToolExecutionException(message: String) : RuntimeException(message)
+
+internal class SaveMcpTools {
+    private val tools = listOf(
+        ToolDefinition(
+            name = "save_get_schema",
+            title = "Get Clash Save Schema",
+            description = "Returns the known binary layout, object paths, aggregate sizes, and editable fields.",
+            inputSchema = objectSchema(
+                properties = linkedMapOf(
+                    "entityType" to stringSchema(
+                        "Optional entity type to narrow the schema. Allowed values: Save, Tile, Player, Army, Unit, Castle."
+                    )
+                )
+            )
+        ),
+        ToolDefinition(
+            name = "save_get_overview",
+            title = "Inspect Clash Save Overview",
+            description = "Loads a save file and Returns high-level metadata, parsed entity counts, and short entity previews.",
+            inputSchema = objectSchema(
+                properties = linkedMapOf(
+                    "path" to stringSchema("Path to a Clash save .dat file."),
+                    "limit" to integerSchema("Maximum preview rows per entity type.", minimum = 1, maximum = 100)
+                ),
+                required = listOf("path")
+            )
+        ),
+        ToolDefinition(
+            name = "save_list_entities",
+            title = "List Parsed Save Entities",
+            description = "Lists parsed tiles, players, armies, castles, army units, or castle units with compact summaries.",
+            inputSchema = objectSchema(
+                properties = linkedMapOf(
+                    "path" to stringSchema("Path to a Clash save .dat file."),
+                    "entityType" to stringSchema("One of: tiles, players, armies, castles, armyUnits, castleUnits."),
+                    "offset" to integerSchema("Zero-based result offset.", minimum = 0),
+                    "limit" to integerSchema("Maximum result count.", minimum = 1, maximum = 500)
+                ),
+                required = listOf("path", "entityType")
+            )
+        ),
+        ToolDefinition(
+            name = "save_read_object",
+            title = "Read Parsed Save Object",
+            description = "Reads a parsed object by path, such as save, tiles[42], players[0], armies[3].units[0], or castles[0].units[2].",
+            inputSchema = objectSchema(
+                properties = linkedMapOf(
+                    "path" to stringSchema("Path to a Clash save .dat file."),
+                    "objectPath" to stringSchema("Object path to inspect."),
+                    "includeBytes" to booleanSchema("Whether to include bytes from the object's record."),
+                    "byteLimit" to integerSchema("Maximum object bytes to return when includeBytes is true.", minimum = 1, maximum = 4096)
+                ),
+                required = listOf("path", "objectPath")
+            )
+        ),
+        ToolDefinition(
+            name = "save_set_property",
+            title = "Set Parsed Save Property",
+            description = "Sets one annotated simple property on a parsed object and writes the modified save to outputPath or in place.",
+            inputSchema = objectSchema(
+                properties = linkedMapOf(
+                    "path" to stringSchema("Path to a Clash save .dat file."),
+                    "objectPath" to stringSchema("Object path containing the property, for example players[0] or castles[0].units[0]."),
+                    "property" to stringSchema("Annotated simple property name to edit."),
+                    "value" to linkedMapOf(
+                        "description" to "New value. Use a string for string fields, integer for integer fields, or integer array for byte-list fields."
+                    ),
+                    "outputPath" to stringSchema("Where to write the modified save. Required unless inPlace is true."),
+                    "inPlace" to booleanSchema("When true and outputPath is omitted, overwrite path."),
+                    "overwrite" to booleanSchema("When true, allow replacing an existing outputPath."),
+                    "createBackup" to booleanSchema("When writing in place, create a .bak copy first. Defaults to true.")
+                ),
+                required = listOf("path", "objectPath", "property", "value")
+            )
+        ),
+        ToolDefinition(
+            name = "save_read_bytes",
+            title = "Read Raw Save Bytes",
+            description = "Reads raw bytes at an absolute file offset for inspecting known or unknown save fields.",
+            inputSchema = objectSchema(
+                properties = linkedMapOf(
+                    "path" to stringSchema("Path to a Clash save .dat file."),
+                    "offset" to integerSchema("Absolute byte offset.", minimum = 0),
+                    "length" to integerSchema("Number of bytes to read.", minimum = 1, maximum = 4096)
+                ),
+                required = listOf("path", "offset", "length")
+            )
+        ),
+        ToolDefinition(
+            name = "save_write_bytes",
+            title = "Write Raw Save Bytes",
+            description = "Writes explicit raw bytes at an absolute file offset and saves to outputPath or in place.",
+            inputSchema = objectSchema(
+                properties = linkedMapOf(
+                    "path" to stringSchema("Path to a Clash save .dat file."),
+                    "offset" to integerSchema("Absolute byte offset.", minimum = 0),
+                    "values" to linkedMapOf(
+                        "description" to "Bytes to write, either as an array of integers 0..255 or a string like '01 FF 00'."
+                    ),
+                    "outputPath" to stringSchema("Where to write the modified save. Required unless inPlace is true."),
+                    "inPlace" to booleanSchema("When true and outputPath is omitted, overwrite path."),
+                    "overwrite" to booleanSchema("When true, allow replacing an existing outputPath."),
+                    "createBackup" to booleanSchema("When writing in place, create a .bak copy first. Defaults to true.")
+                ),
+                required = listOf("path", "offset", "values")
+            )
+        )
+    )
+
+    fun listTools(): List<ToolDefinition> = tools
+
+    fun call(name: String, arguments: Map<String, Any?>): ToolCallResult {
+        return try {
+            val structured = when (name) {
+                "save_get_schema" -> getSchema(arguments)
+                "save_get_overview" -> getOverview(arguments)
+                "save_list_entities" -> listEntities(arguments)
+                "save_read_object" -> readObject(arguments)
+                "save_set_property" -> setProperty(arguments)
+                "save_read_bytes" -> readBytes(arguments)
+                "save_write_bytes" -> writeBytes(arguments)
+                else -> throw ToolExecutionException("Unknown tool: $name")
+            }
+            ToolCallResult(structuredContent = structured)
+        } catch (exception: ToolExecutionException) {
+            ToolCallResult(
+                structuredContent = linkedMapOf("error" to exception.message),
+                text = exception.message ?: "Tool execution failed",
+                isError = true
+            )
+        } catch (exception: Exception) {
+            ToolCallResult(
+                structuredContent = linkedMapOf("error" to (exception.message ?: exception::class.simpleName)),
+                text = exception.message ?: "Tool execution failed",
+                isError = true
+            )
+        }
+    }
+
+    private fun getSchema(arguments: Map<String, Any?>): Map<String, Any?> {
+        val requestedType = optionalStringArg(arguments, "entityType")?.lowercase()
+        val types = linkedMapOf(
+            "save" to Save::class,
+            "tile" to Tile::class,
+            "player" to Player::class,
+            "army" to Army::class,
+            "unit" to ClashUnit::class,
+            "castle" to Castle::class
+        )
+
+        val selectedTypes = if (requestedType == null) {
+            types
+        } else {
+            val klass = types[requestedType] ?: throw ToolExecutionException(
+                "Unsupported entityType '$requestedType'. Use one of: ${types.keys.joinToString(", ")}."
+            )
+            linkedMapOf(requestedType to klass)
+        }
+
+        return linkedMapOf(
+            "minimumRepresentedSaveSize" to MINIMUM_REPRESENTED_SAVE_SIZE,
+            "objectPathExamples" to listOf(
+                "save",
+                "tiles[0]",
+                "players[0]",
+                "armies[0]",
+                "armies[0].units[0]",
+                "castles[0]",
+                "castles[0].units[0]"
+            ),
+            "types" to selectedTypes.mapValues { (_, klass) -> schemaForClass(klass) }
+        )
+    }
+
+    private fun getOverview(arguments: Map<String, Any?>): Map<String, Any?> {
+        val loaded = loadSave(arguments)
+        val save = loaded.save
+        val limit = intArg(arguments, "limit", default = 10).coerceIn(1, 100)
+
+        return linkedMapOf(
+            "path" to loaded.file.absolutePath,
+            "fileSize" to loaded.originalBytes.size,
+            "minimumRepresentedSaveSize" to MINIMUM_REPRESENTED_SAVE_SIZE,
+            "saveName" to save.name,
+            "map" to linkedMapOf(
+                "width" to mapWidthOrDefault(save),
+                "height" to mapHeightOrDefault(save),
+                "storedWidth" to save.mapWidthTiles,
+                "storedHeight" to save.mapHeightTiles
+            ),
+            "view" to linkedMapOf(
+                "left" to save.mapViewLeft,
+                "top" to save.mapViewTop,
+                "activeMissionIndex" to save.activeMissionIndex,
+                "turnOwnerPlayerIndex" to save.turnOwnerPlayerIndex,
+                "viewedPlayerIndex" to save.viewedPlayerIndex
+            ),
+            "counts" to linkedMapOf(
+                "tiles" to save.tiles.size,
+                "players" to save.players.size,
+                "activePlayers" to save.players.count { it.isActive != 0 },
+                "armies" to save.armies.size,
+                "castles" to save.castles.size,
+                "armyUnits" to save.armies.sumOf { it.units.size },
+                "castleUnits" to save.castles.sumOf { it.units.size }
+            ),
+            "players" to save.players.take(limit).mapIndexed { index, player -> playerSummary(index, player) },
+            "armies" to save.armies.take(limit).mapIndexed { index, army -> armySummary(index, army, save) },
+            "castles" to save.castles.take(limit).mapIndexed { index, castle -> castleSummary(index, castle) }
+        )
+    }
+
+    private fun listEntities(arguments: Map<String, Any?>): Map<String, Any?> {
+        val loaded = loadSave(arguments)
+        val save = loaded.save
+        val entityType = normalizeEntityType(stringArg(arguments, "entityType"))
+        val offset = intArg(arguments, "offset", default = 0).coerceAtLeast(0)
+        val limit = intArg(arguments, "limit", default = 50).coerceIn(1, 500)
+
+        val items = when (entityType) {
+            "tiles" -> save.tiles.mapIndexed { index, tile -> tileSummary(index, tile, save) }
+            "players" -> save.players.mapIndexed { index, player -> playerSummary(index, player) }
+            "armies" -> save.armies.mapIndexed { index, army -> armySummary(index, army, save) }
+            "castles" -> save.castles.mapIndexed { index, castle -> castleSummary(index, castle) }
+            "armyUnits" -> save.armies.flatMapIndexed { armyIndex, army ->
+                army.units.mapIndexed { slotIndex, unit -> armyUnitSummary(armyIndex, slotIndex, army, unit, save) }
+            }
+            "castleUnits" -> save.castles.flatMapIndexed { castleIndex, castle ->
+                castle.units.mapIndexed { slotIndex, unit -> castleUnitSummary(castleIndex, slotIndex, castle, unit) }
+            }
+            else -> throw ToolExecutionException(
+                "Unsupported entityType '$entityType'. Use one of: tiles, players, armies, castles, armyUnits, castleUnits."
+            )
+        }
+
+        return linkedMapOf(
+            "path" to loaded.file.absolutePath,
+            "entityType" to entityType,
+            "total" to items.size,
+            "offset" to offset,
+            "limit" to limit,
+            "items" to items.drop(offset).take(limit)
+        )
+    }
+
+    private fun readObject(arguments: Map<String, Any?>): Map<String, Any?> {
+        val loaded = loadSave(arguments)
+        val objectPath = stringArg(arguments, "objectPath")
+        val resolution = resolveObject(loaded.save, objectPath)
+        val includeBytes = boolArg(arguments, "includeBytes", default = false)
+        val byteLimit = intArg(arguments, "byteLimit", default = 256).coerceIn(1, 4096)
+        return describeObject(resolution, includeBytes, byteLimit)
+    }
+
+    private fun setProperty(arguments: Map<String, Any?>): Map<String, Any?> {
+        val loaded = loadSave(arguments)
+        val objectPath = stringArg(arguments, "objectPath")
+        val propertyName = stringArg(arguments, "property")
+        if (!arguments.containsKey("value")) {
+            throw ToolExecutionException("Missing required argument: value")
+        }
+
+        val resolution = resolveObject(loaded.save, objectPath)
+        val descriptor = getClassDescriptor(resolution.obj::class).getSimpleProperty(propertyName)
+            ?: throw ToolExecutionException("Property '$propertyName' is not an editable simple property on ${typeName(resolution.obj)}.")
+
+        val before = descriptor.get(resolution.obj).asSerializableValue()
+        val convertedValue = convertPropertyValue(arguments["value"], descriptor.get(resolution.obj), propertyName)
+        descriptor.set(resolution.obj, convertedValue)
+        val after = descriptor.get(resolution.obj).asSerializableValue()
+
+        val writeResult = writeSaveOutput(loaded.file, loaded.save.bytes.toByteArray(), arguments)
+        return linkedMapOf(
+            "path" to loaded.file.absolutePath,
+            "objectPath" to resolution.normalizedPath,
+            "property" to propertyName,
+            "absoluteOffset" to absoluteByteIndex(resolution.obj) + descriptor.index(),
+            "length" to descriptor.length(),
+            "before" to before,
+            "after" to after,
+            "write" to writeResult
+        )
+    }
+
+    private fun readBytes(arguments: Map<String, Any?>): Map<String, Any?> {
+        val loaded = loadSave(arguments)
+        val offset = intArg(arguments, "offset")
+        val length = intArg(arguments, "length").coerceIn(1, 4096)
+        if (offset < 0 || offset + length > loaded.originalBytes.size) {
+            throw ToolExecutionException(
+                "Byte range [$offset, ${offset + length}) is outside file size ${loaded.originalBytes.size}."
+            )
+        }
+        val bytes = loaded.originalBytes.copyOfRange(offset, offset + length).map { it.toUnsignedInt() }
+        return linkedMapOf(
+            "path" to loaded.file.absolutePath,
+            "offset" to offset,
+            "length" to length,
+            "hex" to bytes.joinToString(" ") { it.toHex(2) },
+            "bytes" to bytes
+        )
+    }
+
+    private fun writeBytes(arguments: Map<String, Any?>): Map<String, Any?> {
+        val loaded = loadSave(arguments)
+        val offset = intArg(arguments, "offset")
+        val values = bytesArg(arguments, "values")
+        if (offset < 0 || offset + values.size > loaded.originalBytes.size) {
+            throw ToolExecutionException(
+                "Byte range [$offset, ${offset + values.size}) is outside file size ${loaded.originalBytes.size}."
+            )
+        }
+
+        val edited = loaded.originalBytes.copyOf()
+        values.forEachIndexed { index, byte -> edited[offset + index] = byte }
+        val before = loaded.originalBytes.copyOfRange(offset, offset + values.size).map { it.toUnsignedInt() }
+        val after = values.map { it.toUnsignedInt() }
+        val writeResult = writeSaveOutput(loaded.file, edited, arguments)
+        return linkedMapOf(
+            "path" to loaded.file.absolutePath,
+            "offset" to offset,
+            "length" to values.size,
+            "beforeHex" to before.joinToString(" ") { it.toHex(2) },
+            "afterHex" to after.joinToString(" ") { it.toHex(2) },
+            "before" to before,
+            "after" to after,
+            "write" to writeResult
+        )
+    }
+
+    private fun schemaForClass(klass: KClass<out ClashObject>): Map<String, Any?> {
+        val descriptor = getClassDescriptor(klass)
+        return linkedMapOf(
+            "byteLength" to byteLengthForClass(klass),
+            "simpleProperties" to descriptor.getSimpleProperties()
+                .sortedBy { it.index() }
+                .map(::schemaForSimpleProperty),
+            "aggregateProperties" to descriptor.getAggregateProperties()
+                .sortedBy { it.index() }
+                .map(::schemaForAggregateProperty)
+        )
+    }
+
+    private fun schemaForSimpleProperty(property: ClashPropertyDescriptor): Map<String, Any?> {
+        val schema = linkedMapOf(
+            "name" to property.getName(),
+            "offset" to property.index(),
+            "length" to property.length(),
+            "valueType" to (property._property.getter.returnType.jvmErasure.simpleName ?: "unknown"),
+            "encoding" to when (property) {
+                is SignedPropertyDescriptor -> "signedLittleEndian"
+                is MaskedPropertyDescriptor -> "maskedLittleEndian"
+                else -> "littleEndianOrFixedString"
+            },
+            "editable" to true
+        )
+        if (property is MaskedPropertyDescriptor) {
+            schema["mask"] = property.mask()
+            schema["maskHex"] = property.mask().toHex(property.length() * 2)
+            schema["shift"] = property.shift()
+            schema["minimum"] = 0
+            schema["maximum"] = property.mask()
+        }
+        return schema
+    }
+
+    private fun schemaForAggregateProperty(property: AggregatePropertyDescriptor): Map<String, Any?> {
+        return linkedMapOf(
+            "name" to property.getName(),
+            "offset" to property.index(),
+            "count" to property.count(),
+            "entrySize" to property.size(),
+            "totalLength" to property.length(),
+            "elementType" to (property.getConstructor().returnType.jvmErasure.simpleName ?: "ClashObject")
+        )
+    }
+
+    private fun describeObject(
+        resolution: ObjectResolution,
+        includeBytes: Boolean,
+        byteLimit: Int
+    ): Map<String, Any?> {
+        val obj = resolution.obj
+        val descriptor = getClassDescriptor(obj::class)
+        val absoluteByteIndex = absoluteByteIndex(obj)
+        val fields = descriptor.getSimpleProperties()
+            .sortedBy { it.index() }
+            .map { property ->
+                linkedMapOf(
+                    "name" to property.getName(),
+                    "value" to property.get(obj).asSerializableValue(),
+                    "offset" to property.index(),
+                    "absoluteOffset" to absoluteByteIndex + property.index(),
+                    "length" to property.length(),
+                    "valueType" to (property._property.getter.returnType.jvmErasure.simpleName ?: "unknown"),
+                    "editable" to true
+                )
+            }
+
+        val properties = linkedMapOf<String, Any?>()
+        fields.forEach { field -> properties[field["name"].toString()] = field["value"] }
+
+        val aggregates = descriptor.getAggregateProperties()
+            .sortedBy { it.index() }
+            .map { property ->
+                @Suppress("UNCHECKED_CAST")
+                val children = property.get(obj) as List<ClashObject>
+                linkedMapOf(
+                    "name" to property.getName(),
+                    "offset" to property.index(),
+                    "absoluteOffset" to absoluteByteIndex + property.index(),
+                    "entrySize" to property.size(),
+                    "declaredCount" to property.count(),
+                    "parsedCount" to children.size,
+                    "elementType" to (property.getConstructor().returnType.jvmErasure.simpleName ?: "ClashObject")
+                )
+            }
+
+        val result = linkedMapOf<String, Any?>(
+            "objectPath" to resolution.normalizedPath,
+            "type" to typeName(obj),
+            "byteIndex" to obj.index,
+            "absoluteByteIndex" to absoluteByteIndex,
+            "byteLength" to obj.bytes.size,
+            "properties" to properties,
+            "fields" to fields,
+            "aggregates" to aggregates,
+            "derived" to derivedFields(obj, resolution.listIndex)
+        )
+
+        if (includeBytes) {
+            val count = min(byteLimit, obj.bytes.size)
+            val bytes = obj.bytes.take(count).map { it.toUnsignedInt() }
+            result["bytes"] = linkedMapOf(
+                "offset" to absoluteByteIndex,
+                "retunedLength" to count,
+                "truncated" to (count < obj.bytes.size),
+                "hex" to bytes.joinToString(" ") { it.toHex(2) },
+                "values" to bytes
+            )
+        }
+
+        return result
+    }
+
+    private fun derivedFields(obj: ClashObject, listIndex: Int?): Map<String, Any?> {
+        return when (obj) {
+            is Save -> linkedMapOf(
+                "mapWidthOrDefault" to mapWidthOrDefault(obj),
+                "mapHeightOrDefault" to mapHeightOrDefault(obj)
+            )
+
+            is Tile -> {
+                val save = rootSave(obj)
+                val tileIndex = listIndex ?: ((absoluteByteIndex(obj) - 16) / 14)
+                val (row, column) = fromIndex(tileIndex, mapWidthOrDefault(save))
+                linkedMapOf(
+                    "tileIndex" to tileIndex,
+                    "mapRow" to row,
+                    "mapColumn" to column,
+                    "terrainTileIdHex" to obj.terrainTileId.toHex(4),
+                    "overlayTileIdHex" to obj.overlayTileId.toHex(4),
+                    "roadOrBridgeTileIdHex" to obj.roadOrBridgeTileId.toHex(4),
+                    "hasOverlay" to obj.hasOverlay(),
+                    "hasRoadOrBridge" to obj.hasRoadOrBridge(),
+                    "isTemple" to obj.isTemple(),
+                    "templeVariant" to obj.templeVariant(),
+                    "templeVisitedOrEmpty" to obj.templeVisitedOrEmpty(),
+                    "isBuriedTreasure" to obj.isBuriedTreasure()
+                )
+            }
+
+            is Army -> {
+                val save = rootSave(obj)
+                linkedMapOf(
+                    "tileIndex" to (obj.tileRow * mapWidthOrDefault(save) + obj.tileColumn),
+                    "unitCount" to obj.units.size,
+                    "queuedPathWaypoints" to obj.queuedPathWaypoints().map { waypoint ->
+                        linkedMapOf(
+                            "tileRow" to waypoint.tileRow,
+                            "tileColumn" to waypoint.tileColumn,
+                            "cumulativeCost" to waypoint.cumulativeCost
+                        )
+                    }
+                )
+            }
+
+            is ClashUnit -> {
+                val metadata = UnitTypes.metadata(obj.typeId)
+                linkedMapOf(
+                    "unitTypeName" to metadata?.displayName,
+                    "unitLocalizedNames" to metadata?.localizedNames,
+                    "unitSpriteFolder" to metadata?.folder,
+                    "unitCategories" to metadata?.categories?.map { it.name.lowercase() }.orEmpty(),
+                    "experienceLevel" to obj.experienceLevel,
+                    "experienceProgress" to obj.experienceProgress,
+                    "isFullyExperienced" to obj.hasMaximumExperience(),
+                    "lowMoraleFlag" to obj.lowMoraleFlag,
+                    "hasLowMoraleFlag" to obj.hasLowMoraleFlag(),
+                    "moraleBand" to obj.moraleBand(),
+                    "fatigueBand" to obj.fatigueBand(),
+                    "moraleFatigueProtectedType" to obj.isMoraleFatigueProtectedType(),
+                    "stanceBitsHex" to obj.stanceBits.toHex(2),
+                    "stateFlagsHex" to obj.stateFlags.toHex(2),
+                    "stateBits2Hex" to obj.stateBits2.toHex(2),
+                    "auxRuntimeStateHex" to obj.auxRuntimeState.toHex(8)
+                )
+            }
+
+            is Player -> linkedMapOf(
+                "revealedTileCount" to obj.revealedTilesBitset.sumOf { countBits(it) },
+                "prisonerTransferQueueEntries" to obj.prisonerTransferQueueEntries().map { entry ->
+                    linkedMapOf(
+                        "marker" to entry.marker,
+                        "isEmpty" to entry.isEmpty,
+                        "rawBytes" to entry.rawBytes.map { it.toUnsignedInt() }
+                    )
+                }
+            )
+
+            is Castle -> linkedMapOf(
+                "buildingNames" to obj.buildingNames(),
+                "addonSlots" to obj.addonSlots().map { slot ->
+                    linkedMapOf(
+                        "slotIndex" to slot.slotIndex,
+                        "typeId" to slot.typeId,
+                        "typeName" to slot.displayName
+                    )
+                },
+                "addonTypeNames" to obj.addonTypeNames(),
+                "garrisonOrders" to obj.garrisonOrders().map { order ->
+                    linkedMapOf(
+                        "rawValue" to order.rawValue,
+                        "trainCountdown" to order.trainCountdown,
+                        "repairCountdown" to order.repairCountdown
+                    )
+                },
+                "prisonerSlots" to obj.prisonerSlots().map { slot ->
+                    linkedMapOf(
+                        "marker" to slot.marker,
+                        "rawBytes" to slot.rawBytes.map { it.toUnsignedInt() }
+                    )
+                }
+            )
+
+            else -> emptyMap()
+        }
+    }
+
+    private fun tileSummary(index: Int, tile: Tile, save: Save): Map<String, Any?> {
+        val (row, column) = fromIndex(index, mapWidthOrDefault(save))
+        return linkedMapOf(
+            "objectPath" to "tiles[$index]",
+            "absoluteByteIndex" to absoluteByteIndex(tile),
+            "index" to index,
+            "row" to row,
+            "column" to column,
+            "terrainTileId" to tile.terrainTileId,
+            "terrainTileIdHex" to tile.terrainTileId.toHex(4),
+            "overlayTileId" to tile.overlayTileId,
+            "overlayTileIdHex" to tile.overlayTileId.toHex(4),
+            "roadOrBridgeTileId" to tile.roadOrBridgeTileId,
+            "roadOrBridgeTileIdHex" to tile.roadOrBridgeTileId.toHex(4),
+            "isTemple" to tile.isTemple(),
+            "templeVariant" to tile.templeVariant(),
+            "templeVisitedOrEmpty" to tile.templeVisitedOrEmpty(),
+            "isBuriedTreasure" to tile.isBuriedTreasure()
+        )
+    }
+
+    private fun playerSummary(index: Int, player: Player): Map<String, Any?> {
+        return linkedMapOf(
+            "objectPath" to "players[$index]",
+            "absoluteByteIndex" to absoluteByteIndex(player),
+            "index" to index,
+            "displayName" to player.displayName,
+            "isActive" to player.isActive,
+            "controllerMode" to player.controllerMode,
+            "religionFlag" to player.religionFlag,
+            "techLevel" to player.techLevel,
+            "queenRelationshipState" to player.queenRelationshipState,
+            "revealedTileCount" to player.revealedTilesBitset.sumOf { countBits(it) }
+        )
+    }
+
+    private fun armySummary(index: Int, army: Army, save: Save): Map<String, Any?> {
+        return linkedMapOf(
+            "objectPath" to "armies[$index]",
+            "absoluteByteIndex" to absoluteByteIndex(army),
+            "index" to index,
+            "tileRow" to army.tileRow,
+            "tileColumn" to army.tileColumn,
+            "tileIndex" to (army.tileRow * mapWidthOrDefault(save) + army.tileColumn),
+            "ownerPlayerIndex" to army.ownerPlayerIndex,
+            "facingDirection" to army.facingDirection,
+            "unitCount" to army.units.size,
+            "queuedPathWaypointCount" to army.queuedPathWaypointCount,
+            "isHiddenOnWorldMap" to army.isHiddenOnWorldMap
+        )
+    }
+
+    private fun castleSummary(index: Int, castle: Castle): Map<String, Any?> {
+        return linkedMapOf(
+            "objectPath" to "castles[$index]",
+            "absoluteByteIndex" to absoluteByteIndex(castle),
+            "index" to index,
+            "displayName" to castle.displayName,
+            "tileRow" to castle.tileRow,
+            "tileColumn" to castle.tileColumn,
+            "ownerPlayerIndex" to castle.ownerPlayerIndex,
+            "appearance" to castle.appearance,
+            "footprintClass" to castle.footprintClass,
+            "unitCount" to castle.units.size,
+            "wallStrength" to castle.wallStrength,
+            "storedMoney" to castle.storedMoney,
+            "buildingNames" to castle.buildingNames(),
+            "addonTypeNames" to castle.addonTypeNames()
+        )
+    }
+
+    private fun armyUnitSummary(
+        armyIndex: Int,
+        slotIndex: Int,
+        army: Army,
+        unit: ClashUnit,
+        save: Save
+    ): Map<String, Any?> {
+        return unitSummary(
+            objectPath = "armies[$armyIndex].units[$slotIndex]",
+            unit = unit,
+            location = linkedMapOf(
+                "armyIndex" to armyIndex,
+                "slotIndex" to slotIndex,
+                "tileRow" to army.tileRow,
+                "tileColumn" to army.tileColumn,
+                "tileIndex" to (army.tileRow * mapWidthOrDefault(save) + army.tileColumn)
+            )
+        )
+    }
+
+    private fun castleUnitSummary(
+        castleIndex: Int,
+        slotIndex: Int,
+        castle: Castle,
+        unit: ClashUnit
+    ): Map<String, Any?> {
+        return unitSummary(
+            objectPath = "castles[$castleIndex].units[$slotIndex]",
+            unit = unit,
+            location = linkedMapOf(
+                "castleIndex" to castleIndex,
+                "slotIndex" to slotIndex,
+                "tileRow" to castle.tileRow,
+                "tileColumn" to castle.tileColumn
+            )
+        )
+    }
+
+    private fun unitSummary(
+        objectPath: String,
+        unit: ClashUnit,
+        location: Map<String, Any?>
+    ): Map<String, Any?> {
+        val metadata = UnitTypes.metadata(unit.typeId)
+        return linkedMapOf(
+            "objectPath" to objectPath,
+            "absoluteByteIndex" to absoluteByteIndex(unit),
+            "location" to location,
+            "typeId" to unit.typeId,
+            "unitTypeName" to metadata?.displayName,
+            "ownerPlayerIndex" to unit.ownerPlayerIndex,
+            "currentActionPoints" to unit.currentActionPoints,
+            "currentHealthPercent" to unit.currentHealthPercent,
+            "fatigue" to unit.fatigue,
+            "morale" to unit.morale,
+            "experienceLevel" to unit.experienceLevel,
+            "experienceProgress" to unit.experienceProgress,
+            "isFullyExperienced" to unit.hasMaximumExperience(),
+            "hasLowMoraleFlag" to unit.hasLowMoraleFlag(),
+            "moraleBand" to unit.moraleBand(),
+            "fatigueBand" to unit.fatigueBand(),
+            "stanceBitsHex" to unit.stanceBits.toHex(2),
+            "stateFlagsHex" to unit.stateFlags.toHex(2),
+            "stateBits2Hex" to unit.stateBits2.toHex(2)
+        )
+    }
+
+    private fun resolveObject(save: Save, objectPath: String): ObjectResolution {
+        var path = objectPath.trim()
+        if (path == "$" || path == "save" || path.isEmpty()) {
+            return ObjectResolution(save, "save", null)
+        }
+        if (path.startsWith("$.")) {
+            path = path.removePrefix("$.")
+        }
+        if (path.startsWith("save.")) {
+            path = path.removePrefix("save.")
+        }
+
+        var current: ClashObject = save
+        var normalizedPath = "save"
+        var listIndex: Int? = null
+
+        path.split(".").filter { it.isNotBlank() }.forEach { segment ->
+            val match = OBJECT_SEGMENT.matchEntire(segment)
+                ?: throw ToolExecutionException("Invalid object path segment '$segment'. Use aggregate[index], for example armies[0].")
+            val aggregateName = match.groupValues[1]
+            val index = match.groupValues[2].toInt()
+            val aggregate = getClassDescriptor(current::class).getAggregateProperty(aggregateName)
+                ?: throw ToolExecutionException("${typeName(current)} has no aggregate property '$aggregateName'.")
+            @Suppress("UNCHECKED_CAST")
+            val children = aggregate.get(current) as List<ClashObject>
+            if (index !in children.indices) {
+                throw ToolExecutionException(
+                    "Index $index is outside parsed ${typeName(current)}.$aggregateName range 0..${children.lastIndex}."
+                )
+            }
+            current = children[index]
+            normalizedPath += ".$aggregateName[$index]"
+            listIndex = index
+        }
+
+        return ObjectResolution(current, normalizedPath.removePrefix("save."), listIndex)
+    }
+
+    private fun loadSave(arguments: Map<String, Any?>): LoadedSave {
+        val path = stringArg(arguments, "path")
+        val file = File(path).absoluteFile
+        if (!file.isFile) {
+            throw ToolExecutionException("Save file does not exist: ${file.absolutePath}")
+        }
+
+        val bytes = file.readBytes()
+        if (bytes.size < MINIMUM_REPRESENTED_SAVE_SIZE) {
+            throw ToolExecutionException(
+                "File is too small to be a represented Clash save: ${bytes.size} bytes, expected at least $MINIMUM_REPRESENTED_SAVE_SIZE."
+            )
+        }
+
+        return LoadedSave(file, bytes, Save().withBytes(bytes.toList()))
+    }
+
+    private fun writeSaveOutput(
+        inputFile: File,
+        bytes: ByteArray,
+        arguments: Map<String, Any?>
+    ): Map<String, Any?> {
+        val outputPath = optionalStringArg(arguments, "outputPath")
+        val inPlace = boolArg(arguments, "inPlace", default = false)
+        val overwrite = boolArg(arguments, "overwrite", default = false)
+        val createBackup = boolArg(arguments, "createBackup", default = true)
+        val outputFile = when {
+            !outputPath.isNullOrBlank() -> File(outputPath).absoluteFile
+            inPlace -> inputFile.absoluteFile
+            else -> throw ToolExecutionException("Provide outputPath or set inPlace=true to write modified bytes.")
+        }
+
+        val sameFile = inputFile.canonicalPath == outputFile.canonicalPath
+        val parent = outputFile.parentFile
+        if (parent != null && !parent.isDirectory) {
+            throw ToolExecutionException("Output directory does not exist: ${parent.absolutePath}")
+        }
+        if (outputFile.exists() && !sameFile && !overwrite) {
+            throw ToolExecutionException("Output file already exists. Set overwrite=true to replace it: ${outputFile.absolutePath}")
+        }
+
+        val backupFile = if (sameFile && createBackup) {
+            nextBackupFile(inputFile).also { inputFile.copyTo(it, overwrite = false) }
+        } else {
+            null
+        }
+
+        outputFile.writeBytes(bytes)
+        return linkedMapOf(
+            "outputPath" to outputFile.absolutePath,
+            "bytesWritten" to bytes.size,
+            "inPlace" to sameFile,
+            "backupPath" to backupFile?.absolutePath
+        )
+    }
+
+    private fun nextBackupFile(inputFile: File): File {
+        val directory = inputFile.parentFile ?: File(".")
+        val first = File(directory, "${inputFile.name}.bak")
+        if (!first.exists()) {
+            return first
+        }
+        for (index in 1..9999) {
+            val candidate = File(directory, "${inputFile.name}.bak.$index")
+            if (!candidate.exists()) {
+                return candidate
+            }
+        }
+        throw ToolExecutionException("Could not choose a backup path for ${inputFile.absolutePath}")
+    }
+
+    private fun convertPropertyValue(value: Any?, currentValue: Any?, propertyName: String): Any {
+        if (value == null) {
+            throw ToolExecutionException("Property '$propertyName' cannot be set to null.")
+        }
+
+        return when (currentValue) {
+            is String -> value as? String
+                ?: throw ToolExecutionException("Property '$propertyName' expects a string value.")
+
+            is Int -> intValue(value, propertyName)
+            is Byte -> byteValue(value, propertyName)
+            is List<*> -> bytesValue(value, propertyName)
+            else -> throw ToolExecutionException("Unsupported property type for '$propertyName': ${currentValue?.let { it::class.simpleName }}")
+        }
+    }
+
+    private fun intValue(value: Any, propertyName: String): Int {
+        return when (value) {
+            is Number -> {
+                val long = value.toLong()
+                if (long < Int.MIN_VALUE || long > Int.MAX_VALUE) {
+                    throw ToolExecutionException("Property '$propertyName' is outside Int range: $value")
+                }
+                long.toInt()
+            }
+
+            is String -> value.toIntOrNull()
+                ?: throw ToolExecutionException("Property '$propertyName' expects an integer value.")
+
+            else -> throw ToolExecutionException("Property '$propertyName' expects an integer value.")
+        }
+    }
+
+    private fun byteValue(value: Any, propertyName: String): Byte {
+        val int = intValue(value, propertyName)
+        if (int !in 0..255) {
+            throw ToolExecutionException("Property '$propertyName' byte value must be in range 0..255.")
+        }
+        return int.toByte()
+    }
+
+    private fun bytesValue(value: Any, propertyName: String): List<Byte> {
+        return when (value) {
+            is List<*> -> value.mapIndexed { index, element ->
+                byteValue(element ?: throw ToolExecutionException("Byte list '$propertyName' contains null at index $index."), propertyName)
+            }
+
+            is String -> parseByteString(value)
+            else -> throw ToolExecutionException("Property '$propertyName' expects an array of bytes or a byte string.")
+        }
+    }
+
+    private fun bytesArg(arguments: Map<String, Any?>, name: String): ByteArray {
+        val value = arguments[name] ?: throw ToolExecutionException("Missing required argument: $name")
+        return when (value) {
+            is List<*> -> value.mapIndexed { index, element ->
+                byteValue(element ?: throw ToolExecutionException("Byte list '$name' contains null at index $index."), name)
+            }.toByteArray()
+
+            is String -> parseByteString(value).toByteArray()
+            else -> throw ToolExecutionException("Argument '$name' expects an array of bytes or a byte string.")
+        }
+    }
+
+    private fun normalizeEntityType(value: String): String {
+        return when (value.lowercase().replace("_", "").replace("-", "")) {
+            "tiles" -> "tiles"
+            "players" -> "players"
+            "armies" -> "armies"
+            "castles" -> "castles"
+            "armyunits" -> "armyUnits"
+            "castleunits" -> "castleUnits"
+            else -> throw ToolExecutionException(
+                "Unsupported entityType '$value'. Use one of: tiles, players, armies, castles, armyUnits, castleUnits."
+            )
+        }
+    }
+
+    private fun parseByteString(value: String): List<Byte> {
+        val tokens = value.trim()
+            .removePrefix("[")
+            .removeSuffix("]")
+            .split(Regex("[,\\s]+"))
+            .filter { it.isNotBlank() }
+        if (tokens.isEmpty()) {
+            throw ToolExecutionException("Byte string is empty.")
+        }
+
+        return tokens.map { token ->
+            val trimmed = token.trim()
+            val radix = if (
+                trimmed.startsWith("0x", ignoreCase = true) ||
+                trimmed.any { it.uppercaseChar() in 'A'..'F' } ||
+                trimmed.length <= 2
+            ) 16 else 10
+            val text = trimmed.removePrefix("0x").removePrefix("0X")
+            val int = text.toIntOrNull(radix)
+                ?: throw ToolExecutionException("Invalid byte token '$token'.")
+            if (int !in 0..255) {
+                throw ToolExecutionException("Byte token '$token' is outside range 0..255.")
+            }
+            int.toByte()
+        }
+    }
+
+    private fun stringArg(arguments: Map<String, Any?>, name: String): String {
+        return optionalStringArg(arguments, name) ?: throw ToolExecutionException("Missing required argument: $name")
+    }
+
+    private fun optionalStringArg(arguments: Map<String, Any?>, name: String): String? {
+        val value = arguments[name] ?: return null
+        return value as? String ?: throw ToolExecutionException("Argument '$name' expects a string.")
+    }
+
+    private fun intArg(arguments: Map<String, Any?>, name: String, default: Int? = null): Int {
+        val value = arguments[name] ?: return default ?: throw ToolExecutionException("Missing required argument: $name")
+        return when (value) {
+            is Number -> value.toLong().let { long ->
+                if (long < Int.MIN_VALUE || long > Int.MAX_VALUE) {
+                    throw ToolExecutionException("Argument '$name' is outside Int range: $value")
+                }
+                long.toInt()
+            }
+
+            is String -> value.toIntOrNull() ?: throw ToolExecutionException("Argument '$name' expects an integer.")
+            else -> throw ToolExecutionException("Argument '$name' expects an integer.")
+        }
+    }
+
+    private fun boolArg(arguments: Map<String, Any?>, name: String, default: Boolean): Boolean {
+        val value = arguments[name] ?: return default
+        return value as? Boolean ?: throw ToolExecutionException("Argument '$name' expects a boolean.")
+    }
+
+    private fun absoluteByteIndex(obj: ClashObject): Int {
+        var total = 0
+        var current: ClashObject? = obj
+        while (current != null) {
+            total += current.index
+            current = current.parent
+        }
+        return total
+    }
+
+    private fun rootSave(obj: ClashObject): Save {
+        var current: ClashObject = obj
+        while (current.parent != null) {
+            current = current.parent!!
+        }
+        return current as? Save ?: throw ToolExecutionException("Object is not attached to a Save root.")
+    }
+
+    private fun typeName(obj: ClashObject): String {
+        return obj::class.simpleName ?: "ClashObject"
+    }
+
+    private fun byteLengthForClass(klass: KClass<out ClashObject>): Int {
+        return when (klass) {
+            Save::class -> MINIMUM_REPRESENTED_SAVE_SIZE
+            Tile::class -> 14
+            Player::class -> 1423
+            Army::class -> 725
+            ClashUnit::class -> 31
+            Castle::class -> 467
+            else -> 0
+        }
+    }
+
+    private fun mapWidthOrDefault(save: Save): Int {
+        return save.mapWidthTiles.takeIf { it > 0 } ?: 100
+    }
+
+    private fun mapHeightOrDefault(save: Save): Int {
+        return save.mapHeightTiles.takeIf { it > 0 } ?: 100
+    }
+
+    private fun countBits(byte: Byte): Int {
+        return Integer.bitCount(byte.toInt() and 0xFF)
+    }
+
+    private fun Any?.asSerializableValue(): Any? = when (this) {
+        null -> null
+        is Byte -> toUnsignedInt()
+        is List<*> -> map { element ->
+            when (element) {
+                is Byte -> element.toUnsignedInt()
+                else -> element
+            }
+        }
+
+        else -> this
+    }
+
+    private fun Byte.toUnsignedInt(): Int {
+        return toInt() and 0xFF
+    }
+
+    private fun Int.toHex(width: Int): String {
+        return "0x" + toUInt().toString(16).uppercase().padStart(width, '0')
+    }
+
+    private fun objectSchema(
+        properties: Map<String, Any?>,
+        required: List<String> = emptyList()
+    ): Map<String, Any?> {
+        val schema = linkedMapOf<String, Any?>(
+            "type" to "object",
+            "properties" to properties,
+            "additionalProperties" to false
+        )
+        if (required.isNotEmpty()) {
+            schema["required"] = required
+        }
+        return schema
+    }
+
+    private fun stringSchema(description: String): Map<String, Any?> {
+        return linkedMapOf("type" to "string", "description" to description)
+    }
+
+    private fun integerSchema(description: String, minimum: Int? = null, maximum: Int? = null): Map<String, Any?> {
+        val schema = linkedMapOf<String, Any?>("type" to "integer", "description" to description)
+        minimum?.let { schema["minimum"] = it }
+        maximum?.let { schema["maximum"] = it }
+        return schema
+    }
+
+    private fun booleanSchema(description: String): Map<String, Any?> {
+        return linkedMapOf("type" to "boolean", "description" to description)
+    }
+
+    private data class LoadedSave(
+        val file: File,
+        val originalBytes: ByteArray,
+        val save: Save
+    )
+
+    private data class ObjectResolution(
+        val obj: ClashObject,
+        val normalizedPath: String,
+        val listIndex: Int?
+    )
+
+    private companion object {
+        val OBJECT_SEGMENT = Regex("""([A-Za-z_][A-Za-z0-9_]*)\[(\d+)]""")
+    }
+}

--- a/src/com/lis/clash/objects/Castle.kt
+++ b/src/com/lis/clash/objects/Castle.kt
@@ -1,6 +1,8 @@
 package com.lis.clash.objects
 
 import com.lis.clash.ClashAggregateProperty
+import com.lis.clash.CastleAddonSlot
+import com.lis.clash.CastleAddonTypes
 import com.lis.clash.GarrisonOrder
 import com.lis.clash.ClashMaskedProperty
 import com.lis.clash.RawSixByteRecord
@@ -95,6 +97,23 @@ class Castle(parent: ClashObject, index: Int) : ClashObject(parent, index) {
         if (hasBuilding(BUILDING_SCHOOL)) result += "school"
         if (hasBuilding(BUILDING_SMITHS)) result += "smiths"
         return result
+    }
+
+    fun addonSlots(): List<CastleAddonSlot> {
+        return addonTypeIds.mapIndexedNotNull { slotIndex, rawTypeId ->
+            val typeId = rawTypeId.toInt() and 0xFF
+            if (typeId == CastleAddonTypes.EMPTY_SLOT) {
+                null
+            } else {
+                CastleAddonSlot(slotIndex, typeId, CastleAddonTypes.metadata(typeId)?.displayName)
+            }
+        }
+    }
+
+    fun addonTypeNames(): List<String> {
+        return addonSlots().map { slot ->
+            slot.displayName ?: "unknown(${slot.typeId})"
+        }
     }
 
     fun garrisonOrders(): List<GarrisonOrder> {

--- a/src/com/lis/clash/objects/Save.kt
+++ b/src/com/lis/clash/objects/Save.kt
@@ -10,19 +10,19 @@ class Save : ClashObject(null, 0) {
     @ClashAggregateProperty(16, 10000, 14, Tile::class)
     var tiles: List<Tile> by clashProperty(emptyList())
 
-    @ClashSimpleProperty(140000, 4)
+    @ClashSimpleProperty(140016, 4)
     var mapWidthTiles: Int by clashProperty(0)
 
-    @ClashSimpleProperty(140004, 4)
+    @ClashSimpleProperty(140020, 4)
     var mapHeightTiles: Int by clashProperty(0)
 
-    @ClashSimpleProperty(140008, 4)
+    @ClashSimpleProperty(140024, 4)
     var mapViewLeft: Int by clashProperty(0)
 
-    @ClashSimpleProperty(140012, 4)
+    @ClashSimpleProperty(140028, 4)
     var mapViewTop: Int by clashProperty(0)
 
-    @ClashSimpleProperty(140017, 4)
+    @ClashSimpleProperty(140032, 4)
     var activeMissionIndex: Int by clashProperty(0)
 
     @ClashAggregateProperty(147190, 500, 725, Army::class)
@@ -31,10 +31,10 @@ class Save : ClashObject(null, 0) {
     @ClashAggregateProperty(140040, 5, 1423, Player::class)
     var players: List<Player> by clashProperty(emptyList())
 
-    @ClashSimpleProperty(147139, 4)
+    @ClashSimpleProperty(147155, 4)
     var turnOwnerPlayerIndex: Int by clashProperty(0)
 
-    @ClashSimpleProperty(147143, 4)
+    @ClashSimpleProperty(147159, 4)
     var viewedPlayerIndex: Int by clashProperty(0)
 
     @ClashAggregateProperty(509690, 10, 467, Castle::class)

--- a/src/com/lis/clash/objects/Tile.kt
+++ b/src/com/lis/clash/objects/Tile.kt
@@ -20,4 +20,35 @@ class Tile(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     fun hasRoadOrBridge(): Boolean {
         return roadOrBridgeTileId != 0xFFFF
     }
+
+    fun isTemple(): Boolean {
+        return overlayTileId in TEMPLE_OVERLAY_IDS
+    }
+
+    fun templeVariant(): Int? {
+        return if (isTemple()) {
+            (overlayTileId - TEMPLE_OVERLAY_ID_START) / 2
+        } else {
+            null
+        }
+    }
+
+    fun templeVisitedOrEmpty(): Boolean? {
+        return if (isTemple()) {
+            (overlayTileId - TEMPLE_OVERLAY_ID_START) % 2 == 1
+        } else {
+            null
+        }
+    }
+
+    fun isBuriedTreasure(): Boolean {
+        return terrainTileId in BURIED_TREASURE_TERRAIN_IDS
+    }
+
+    companion object {
+        const val TEMPLE_OVERLAY_ID_START = 728
+        const val TEMPLE_OVERLAY_ID_END = 739
+        val TEMPLE_OVERLAY_IDS = TEMPLE_OVERLAY_ID_START..TEMPLE_OVERLAY_ID_END
+        val BURIED_TREASURE_TERRAIN_IDS = setOf(752, 755)
+    }
 }

--- a/src/com/lis/clash/objects/Unit.kt
+++ b/src/com/lis/clash/objects/Unit.kt
@@ -1,6 +1,7 @@
 package com.lis.clash.objects
 
 import com.lis.clash.ClashSignedProperty
+import com.lis.clash.ClashMaskedProperty
 import com.lis.clash.ClashSimpleProperty
 
 class Unit(parent: ClashObject, index: Int) : ClashObject(parent, index) {
@@ -25,8 +26,17 @@ class Unit(parent: ClashObject, index: Int) : ClashObject(parent, index) {
     @ClashSimpleProperty(12, 1)
     var stanceBits: Int by clashProperty(0)
 
+    @ClashMaskedProperty(12, 1, 0x03)
+    var experienceLevel: Int by clashProperty(0)
+
+    @ClashMaskedProperty(12, 1, 0x03, 2)
+    var experienceProgress: Int by clashProperty(0)
+
     @ClashSimpleProperty(13, 1)
     var stateFlags: Int by clashProperty(0)
+
+    @ClashMaskedProperty(13, 1, 0x01, 2)
+    var lowMoraleFlag: Int by clashProperty(0)
 
     @ClashSimpleProperty(18, 4)
     var auxRuntimeState: Int by clashProperty(0)
@@ -36,6 +46,45 @@ class Unit(parent: ClashObject, index: Int) : ClashObject(parent, index) {
 
     override fun isValid(): Boolean {
         return typeId != -1
+    }
+
+    fun hasMaximumExperience(): Boolean {
+        return experienceLevel == MAX_EXPERIENCE_LEVEL
+    }
+
+    fun hasLowMoraleFlag(): Boolean {
+        return lowMoraleFlag != 0
+    }
+
+    fun isMoraleFatigueProtectedType(): Boolean {
+        return typeId in MORALE_FATIGUE_PROTECTED_TYPE_IDS
+    }
+
+    fun moraleBand(): String {
+        return when (morale) {
+            in 0..4 -> "low"
+            in 11..15 -> "good"
+            in 16..MAX_MORALE -> "excellent"
+            else -> "normal"
+        }
+    }
+
+    fun fatigueBand(): String {
+        return when (fatigue) {
+            in 80..89 -> "tired"
+            in 90..99 -> "exhausted"
+            MAX_FATIGUE -> "spent"
+            else -> "normal"
+        }
+    }
+
+    companion object {
+        const val MAX_HEALTH_PERCENT = 100
+        const val MAX_FATIGUE = 100
+        const val MAX_MORALE = 20
+        const val MAX_EXPERIENCE_LEVEL = 3
+        const val MAX_EXPERIENCE_PROGRESS = 3
+        val MORALE_FATIGUE_PROTECTED_TYPE_IDS = setOf(31, 32, 33, 34)
     }
 
 }

--- a/src/com/lis/clash/parser.kt
+++ b/src/com/lis/clash/parser.kt
@@ -137,6 +137,14 @@ class MaskedPropertyDescriptor(_property: KMutableProperty<ClashObject>) : Clash
         return value.toInt()
     }
 
+    fun mask(): Int {
+        return annotation.mask
+    }
+
+    fun shift(): Int {
+        return annotation.shift
+    }
+
     override fun fromBytes(value: List<Byte>): Any {
         val rawValue = readLittleEndianInt(value)
         return (rawValue ushr annotation.shift) and annotation.mask

--- a/src/com/lis/clash/scripts.kt
+++ b/src/com/lis/clash/scripts.kt
@@ -101,6 +101,26 @@ object Scripts {
     }
 
     @ClashScript
+    fun listShrines(save: Save): String {
+        return formatLocatedTiles(
+            title = "Shrines",
+            tiles = save.locatedTiles().filter { it.tile.isTemple() }
+        ) { locatedTile ->
+            "terrain=${formatTileId(locatedTile.tile.terrainTileId)} overlay=${formatTileId(locatedTile.tile.overlayTileId)} variant=${locatedTile.tile.templeVariant()} visitedOrEmpty=${locatedTile.tile.templeVisitedOrEmpty()}"
+        }
+    }
+
+    @ClashScript
+    fun listBuriedTreasure(save: Save): String {
+        return formatLocatedTiles(
+            title = "Buried treasure",
+            tiles = save.locatedTiles().filter { it.tile.isBuriedTreasure() }
+        ) { locatedTile ->
+            "terrain=${formatTileId(locatedTile.tile.terrainTileId)} overlay=${formatTileId(locatedTile.tile.overlayTileId)}"
+        }
+    }
+
+    @ClashScript
     fun listQueuedArmyPaths(save: Save): String {
         val queuedArmies = save.armies.mapIndexed { armyIndex, army -> armyIndex to army }
             .filter { (_, army) -> army.queuedPathWaypointCount > 0 }
@@ -223,7 +243,8 @@ object Scripts {
 
         val lines = save.castles.mapIndexed { castleIndex, castle ->
             val buildings = castle.buildingNames().ifEmpty { listOf("none") }
-            "castle#$castleIndex row=${castle.tileRow} column=${castle.tileColumn} owner=${castle.ownerPlayerIndex} flags=${castle.castleAddonFlags.toHex(2)} buildings=${buildings.joinToString(",")}"
+            val addons = castle.addonTypeNames().ifEmpty { listOf("none") }
+            "castle#$castleIndex row=${castle.tileRow} column=${castle.tileColumn} owner=${castle.ownerPlayerIndex} flags=${castle.castleAddonFlags.toHex(2)} buildings=${buildings.joinToString(",")} addonTypes=${addons.joinToString(",")}"
         }
         return renderSection("Castle add-on flags", save.castles.size, lines)
     }
@@ -306,6 +327,15 @@ object Scripts {
                 "terrain=${formatTileId(key.first)} overlay=${formatTileId(key.second)} roadOrBridge=${formatTileId(key.third)} count=$count"
             }
         return renderSection("Tile combinations", counts.size, lines, 50)
+    }
+
+    @ClashScript
+    fun summarizeUnitExperience(save: Save): String {
+        return summarizeUnitField(
+            title = "Unit experience levels",
+            values = save.locatedUnits().map { it.unit.experienceLevel },
+            formatter = { value -> value.toString() }
+        )
     }
 
     @ClashScript
@@ -399,6 +429,10 @@ object Scripts {
                 result["roadOrBridgeTileIdHex"] = roadOrBridgeTileId.toHex(4)
                 result["hasOverlay"] = hasOverlay()
                 result["hasRoadOrBridge"] = hasRoadOrBridge()
+                result["isTemple"] = isTemple()
+                result["templeVariant"] = templeVariant()
+                result["templeVisitedOrEmpty"] = templeVisitedOrEmpty()
+                result["isBuriedTreasure"] = isBuriedTreasure()
             }
 
             is Unit -> {
@@ -408,6 +442,11 @@ object Scripts {
                     result["unitSpriteFolder"] = metadata.folder
                     result["unitCategories"] = metadata.categories.map { it.name.lowercase() }
                 }
+                result["isFullyExperienced"] = hasMaximumExperience()
+                result["hasLowMoraleFlag"] = hasLowMoraleFlag()
+                result["moraleBand"] = moraleBand()
+                result["fatigueBand"] = fatigueBand()
+                result["moraleFatigueProtectedType"] = isMoraleFatigueProtectedType()
                 result["stanceBitsHex"] = stanceBits.toHex(2)
                 result["stateFlagsHex"] = stateFlags.toHex(2)
                 result["stateBits2Hex"] = stateBits2.toHex(2)
@@ -438,6 +477,14 @@ object Scripts {
 
             is Castle -> {
                 result["buildingNames"] = buildingNames()
+                result["addonSlots"] = addonSlots().map { slot ->
+                    linkedMapOf<String, Any?>(
+                        "slotIndex" to slot.slotIndex,
+                        "typeId" to slot.typeId,
+                        "typeName" to slot.displayName
+                    )
+                }
+                result["addonTypeNames"] = addonTypeNames()
                 result["garrisonOrders"] = garrisonOrders().map { order ->
                     linkedMapOf<String, Any>(
                         "rawValue" to order.rawValue,
@@ -549,6 +596,12 @@ object Scripts {
                 append(locatedUnit.unit.fatigue)
                 append(" morale=")
                 append(locatedUnit.unit.morale)
+                append(" exp=")
+                append(locatedUnit.unit.experienceLevel)
+                append("/")
+                append(locatedUnit.unit.experienceProgress)
+                append(" moraleBand=")
+                append(locatedUnit.unit.moraleBand())
                 append(" stance=")
                 append(locatedUnit.unit.stanceBits.toHex(2))
                 val extra = extraFormatter(locatedUnit)

--- a/src/com/lis/clash/types.kt
+++ b/src/com/lis/clash/types.kt
@@ -89,3 +89,34 @@ data class GarrisonOrder(
     val repairCountdown: Int
         get() = (rawValue ushr 3) and 0x07
 }
+
+data class CastleAddonTypeMetadata(
+    val id: Int,
+    val displayName: String
+)
+
+object CastleAddonTypes {
+    const val EMPTY_SLOT = 0xFF
+
+    val all = listOf(
+        CastleAddonTypeMetadata(0, "Court"),
+        CastleAddonTypeMetadata(1, "Tower"),
+        CastleAddonTypeMetadata(2, "Hospital"),
+        CastleAddonTypeMetadata(3, "Barracks"),
+        CastleAddonTypeMetadata(4, "Workshop"),
+        CastleAddonTypeMetadata(5, "School"),
+        CastleAddonTypeMetadata(6, "Smiths"),
+        CastleAddonTypeMetadata(7, "Peasants"),
+        CastleAddonTypeMetadata(8, "Barracks")
+    )
+
+    private val byId = all.associateBy(CastleAddonTypeMetadata::id)
+
+    fun metadata(typeId: Int): CastleAddonTypeMetadata? = byId[typeId]
+}
+
+data class CastleAddonSlot(
+    val slotIndex: Int,
+    val typeId: Int,
+    val displayName: String?
+)

--- a/src/test/kotlin/com/lis/clash/MapRenderModelTest.kt
+++ b/src/test/kotlin/com/lis/clash/MapRenderModelTest.kt
@@ -1,0 +1,119 @@
+package com.lis.clash
+
+import com.lis.clash.objects.Save
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MapRenderModelTest {
+    @Test
+    fun coordinateConversionUsesRowsForYAndColumnsForX() {
+        val tileIndex = toIndex(tileRow = 12, tileColumn = 34, mapWidth = 60)
+
+        assertEquals(754, tileIndex)
+        assertEquals(12 to 34, fromIndex(tileIndex, 60))
+        assertEquals(754, tileIndexAt(pixelX = 34 * 8 + 2, pixelY = 12 * 8 + 2, tileSize = 8, mapWidth = 60, mapHeight = 40, tileCount = 2400))
+        assertNull(tileIndexAt(pixelX = 60 * 8, pixelY = 0, tileSize = 8, mapWidth = 60, mapHeight = 40, tileCount = 2400))
+        assertNull(tileIndexAt(pixelX = -1, pixelY = 0, tileSize = 8, mapWidth = 60, mapHeight = 40, tileCount = 2400))
+        assertNull(tileIndexAt(pixelX = 0, pixelY = 0, tileSize = 0, mapWidth = 60, mapHeight = 40, tileCount = 2400))
+    }
+
+    @Test
+    fun renderModelExtractsValidArmiesAndCastles() {
+        val save = Save().withBytes<Save>(buildSyntheticMapSave().toList())
+        val selectedTileIndex = toIndex(tileRow = 12, tileColumn = 34, mapWidth = 60)
+
+        val model = buildMapRenderModel(save, selectedTileIndex)
+
+        assertEquals(60, model.mapWidth)
+        assertEquals(40, model.mapHeight)
+        assertEquals(selectedTileIndex, model.selectedTileIndex)
+
+        assertEquals(1, model.armies.size)
+        assertEquals(MapMarkerType.ARMY, model.armies.single().type)
+        assertEquals(12, model.armies.single().tileRow)
+        assertEquals(34, model.armies.single().tileColumn)
+        assertEquals(2, model.armies.single().ownerPlayerIndex)
+        assertEquals(true, model.armies.single().hidden)
+
+        assertEquals(1, model.castles.size)
+        assertEquals(MapMarkerType.CASTLE, model.castles.single().type)
+        assertEquals(3, model.castles.single().tileRow)
+        assertEquals(4, model.castles.single().tileColumn)
+        assertEquals(1, model.castles.single().ownerPlayerIndex)
+        assertEquals("Keep", model.castles.single().label)
+    }
+
+    @Test
+    fun renderModelPreservesValidSelectionAndHandlesEmptyTiles() {
+        val save = Save().withBytes<Save>(buildSyntheticMapSave().toList())
+        val selectedTileIndex = toIndex(tileRow = 3, tileColumn = 4, mapWidth = 60)
+
+        val model = buildMapRenderModel(save, selectedTileIndex)
+
+        assertEquals(selectedTileIndex, model.selectedTileIndex)
+        assertEquals(EMPTY_TILE_ID, model.tiles.first().terrainTileId)
+        assertEquals(EMPTY_TILE_COLOR, terrainColorFor(EMPTY_TILE_ID))
+        assertEquals(-1, buildMapRenderModel(save, Int.MAX_VALUE).selectedTileIndex)
+    }
+
+    private fun buildSyntheticMapSave(): ByteArray {
+        val bytes = ByteArray(514360)
+
+        repeat(500) { armyIndex ->
+            writeLittleEndian(bytes, 147190 + armyIndex * 725 + 6, 0xFFFF, 2)
+        }
+        repeat(10) { castleIndex ->
+            writeLittleEndian(bytes, 509690 + castleIndex * 467 + 4, 0xFF, 1)
+        }
+
+        writeLittleEndian(bytes, 16, EMPTY_TILE_ID, 2)
+        writeLittleEndian(bytes, 18, EMPTY_TILE_ID, 2)
+        writeLittleEndian(bytes, 20, EMPTY_TILE_ID, 2)
+        writeLittleEndian(bytes, 140016, 60, 4)
+        writeLittleEndian(bytes, 140020, 40, 4)
+
+        val firstArmy = 147190
+        writeLittleEndian(bytes, firstArmy, 12, 2)
+        writeLittleEndian(bytes, firstArmy + 2, 34, 2)
+        writeLittleEndian(bytes, firstArmy + 4, 2, 1)
+        writeLittleEndian(bytes, firstArmy + 6, 5, 2)
+        writeLittleEndian(bytes, firstArmy + 720, 1, 1)
+
+        val outOfBoundsArmy = firstArmy + 725
+        writeLittleEndian(bytes, outOfBoundsArmy, 45, 2)
+        writeLittleEndian(bytes, outOfBoundsArmy + 2, 1, 2)
+        writeLittleEndian(bytes, outOfBoundsArmy + 4, 3, 1)
+        writeLittleEndian(bytes, outOfBoundsArmy + 6, 6, 2)
+
+        val firstCastle = 509690
+        writeLittleEndian(bytes, firstCastle, 3, 1)
+        writeLittleEndian(bytes, firstCastle + 1, 4, 1)
+        writeLittleEndian(bytes, firstCastle + 2, 1, 1)
+        writeLittleEndian(bytes, firstCastle + 4, 2, 1)
+        writeString(bytes, firstCastle + 5, 10, "Keep")
+        writeLittleEndian(bytes, firstCastle + 18, 0xFFFF, 2)
+
+        val outOfBoundsCastle = firstCastle + 467
+        writeLittleEndian(bytes, outOfBoundsCastle, 99, 1)
+        writeLittleEndian(bytes, outOfBoundsCastle + 1, 4, 1)
+        writeLittleEndian(bytes, outOfBoundsCastle + 2, 4, 1)
+        writeLittleEndian(bytes, outOfBoundsCastle + 4, 3, 1)
+        writeLittleEndian(bytes, outOfBoundsCastle + 18, 0xFFFF, 2)
+
+        return bytes
+    }
+
+    private fun writeString(bytes: ByteArray, offset: Int, length: Int, value: String) {
+        val encoded = value.encodeToByteArray()
+        repeat(length) { index ->
+            bytes[offset + index] = encoded.getOrElse(index) { 0 }
+        }
+    }
+
+    private fun writeLittleEndian(bytes: ByteArray, offset: Int, value: Int, length: Int) {
+        writeLittleEndianInt(value, length).forEachIndexed { index, byte ->
+            bytes[offset + index] = byte
+        }
+    }
+}

--- a/src/test/kotlin/com/lis/clash/SaveFormatParsingTest.kt
+++ b/src/test/kotlin/com/lis/clash/SaveFormatParsingTest.kt
@@ -3,6 +3,7 @@ package com.lis.clash
 import com.lis.clash.objects.Save
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.hasAnnotation
@@ -59,7 +60,13 @@ class SaveFormatParsingTest {
         assertEquals(90, unit.fatigue)
         assertEquals(4, unit.morale)
         assertEquals(0x12, unit.stanceBits)
+        assertEquals(2, unit.experienceLevel)
+        assertEquals(0, unit.experienceProgress)
         assertEquals(0x0E, unit.stateFlags)
+        assertEquals(1, unit.lowMoraleFlag)
+        assertTrue(unit.hasLowMoraleFlag())
+        assertEquals("low", unit.moraleBand())
+        assertEquals("exhausted", unit.fatigueBand())
         assertEquals(0x11223344, unit.auxRuntimeState)
         assertEquals(0x03, unit.stateBits2)
 
@@ -70,6 +77,7 @@ class SaveFormatParsingTest {
         assertEquals(3, castle.appearance)
         assertEquals(4, castle.footprintClass)
         assertEquals("CastleOne", castle.displayName)
+        assertEquals(listOf("Court", "Hospital", "Barracks"), castle.addonTypeNames())
         assertEquals(0x1D, castle.garrisonOrders().first().rawValue)
         assertEquals(5, castle.garrisonOrders().first().trainCountdown)
         assertEquals(3, castle.garrisonOrders().first().repairCountdown)
@@ -88,6 +96,66 @@ class SaveFormatParsingTest {
         assertTrue("listQueuedArmyPaths" in scriptNames)
         assertTrue("summarizeWorldViewState" in scriptNames)
         assertTrue("listUnitsWithStateFlags" in scriptNames)
+        assertTrue("summarizeUnitExperience" in scriptNames)
+        assertTrue("listShrines" in scriptNames)
+        assertTrue("listBuriedTreasure" in scriptNames)
+    }
+
+    @Test
+    fun unitExperienceLevelPreservesOtherStanceBits() {
+        val save = Save().withBytes<Save>(buildSyntheticSave().toList())
+        val unit = save.armies.single().units.single()
+
+        assertEquals(0x12, unit.stanceBits)
+        assertEquals(2, unit.experienceLevel)
+
+        unit.experienceLevel = 3
+        assertEquals(0x13, unit.stanceBits)
+        assertEquals(3, unit.experienceLevel)
+        assertEquals(0, unit.experienceProgress)
+        assertTrue(unit.hasMaximumExperience())
+
+        unit.experienceProgress = 3
+        assertEquals(0x1F, unit.stanceBits)
+        assertEquals(3, unit.experienceLevel)
+        assertEquals(3, unit.experienceProgress)
+
+        unit.experienceLevel = 0
+        assertEquals(0x1C, unit.stanceBits)
+        assertEquals(0, unit.experienceLevel)
+        assertEquals(3, unit.experienceProgress)
+    }
+
+    @Test
+    fun unitLowMoraleFlagPreservesOtherStateFlags() {
+        val save = Save().withBytes<Save>(buildSyntheticSave().toList())
+        val unit = save.armies.single().units.single()
+
+        assertEquals(0x0E, unit.stateFlags)
+        assertEquals(1, unit.lowMoraleFlag)
+
+        unit.lowMoraleFlag = 0
+        assertEquals(0x0A, unit.stateFlags)
+        assertEquals(0, unit.lowMoraleFlag)
+        assertFalse(unit.hasLowMoraleFlag())
+    }
+
+    @Test
+    fun templeOverlayHelpersIdentifyShrines() {
+        val save = Save().withBytes<Save>(buildSyntheticSave().toList())
+        val tile = save.tiles.first()
+
+        assertFalse(tile.isTemple())
+        assertEquals(null, tile.templeVariant())
+        assertEquals(null, tile.templeVisitedOrEmpty())
+
+        tile.overlayTileId = 731
+        assertTrue(tile.isTemple())
+        assertEquals(1, tile.templeVariant())
+        assertEquals(true, tile.templeVisitedOrEmpty())
+
+        tile.terrainTileId = 752
+        assertTrue(tile.isBuriedTreasure())
     }
 
     private fun buildSyntheticSave(): ByteArray {
@@ -106,14 +174,14 @@ class SaveFormatParsingTest {
         writeLittleEndian(bytes, 18, 654, 2)
         writeLittleEndian(bytes, 20, 872, 2)
 
-        writeLittleEndian(bytes, 140000, 60, 4)
-        writeLittleEndian(bytes, 140004, 40, 4)
-        writeLittleEndian(bytes, 140008, 7, 4)
-        writeLittleEndian(bytes, 140012, 9, 4)
-        writeLittleEndian(bytes, 140017, -1, 4)
+        writeLittleEndian(bytes, 140016, 60, 4)
+        writeLittleEndian(bytes, 140020, 40, 4)
+        writeLittleEndian(bytes, 140024, 7, 4)
+        writeLittleEndian(bytes, 140028, 9, 4)
+        writeLittleEndian(bytes, 140032, -1, 4)
 
-        writeLittleEndian(bytes, 147139, 2, 4)
-        writeLittleEndian(bytes, 147143, 3, 4)
+        writeLittleEndian(bytes, 147155, 2, 4)
+        writeLittleEndian(bytes, 147159, 3, 4)
 
         val playerBase = 140040
         writeLittleEndian(bytes, playerBase, 1, 4)
@@ -185,6 +253,12 @@ class SaveFormatParsingTest {
         writeLittleEndian(bytes, castleBase + 36, 0x12345678.toInt(), 4)
         writeLittleEndian(bytes, castleBase + 40, 0x01, 1)
         writeLittleEndian(bytes, castleBase + 390, 0x1D, 1)
+        repeat(12) { slotIndex ->
+            writeLittleEndian(bytes, castleBase + 402 + slotIndex, 0xFF, 1)
+        }
+        writeLittleEndian(bytes, castleBase + 402, 0, 1)
+        writeLittleEndian(bytes, castleBase + 403, 2, 1)
+        writeLittleEndian(bytes, castleBase + 404, 3, 1)
         writeLittleEndian(bytes, castleBase + 414, -1, 1)
         writeLittleEndian(bytes, castleBase + 416, 0x13, 1)
         writeLittleEndian(bytes, castleBase + 420, 0x01, 1)

--- a/src/test/kotlin/com/lis/clash/mcp/SaveMcpToolsTest.kt
+++ b/src/test/kotlin/com/lis/clash/mcp/SaveMcpToolsTest.kt
@@ -1,0 +1,270 @@
+package com.lis.clash.mcp
+
+import com.lis.clash.objects.Save
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SaveMcpToolsTest {
+    @Test
+    fun `schema and object reads expose parsed save data`() {
+        val input = writeSyntheticSave()
+        val tools = SaveMcpTools()
+
+        val schema = tools.call("save_get_schema", mapOf("entityType" to "Tile"))
+        assertFalse(schema.isError)
+        val schemaContent = schema.structuredContent.asMap()
+        assertEquals(MINIMUM_REPRESENTED_SAVE_SIZE, schemaContent["minimumRepresentedSaveSize"])
+
+        val unitSchema = tools.call("save_get_schema", mapOf("entityType" to "Unit"))
+        assertFalse(unitSchema.isError)
+        val unitSchemaContent = unitSchema.structuredContent.asMap()
+        val unitTypes = unitSchemaContent["types"].asMap()
+        val unitType = unitTypes["unit"].asMap()
+        val unitProperties = unitType["simpleProperties"].asList().map { it.asMap() }
+        val experience = unitProperties.single { it["name"] == "experienceLevel" }
+        assertEquals(12, experience["offset"])
+        assertEquals("maskedLittleEndian", experience["encoding"])
+        assertEquals(0x03, experience["mask"])
+        assertEquals(3, experience["maximum"])
+
+        val progress = unitProperties.single { it["name"] == "experienceProgress" }
+        assertEquals(12, progress["offset"])
+        assertEquals(2, progress["shift"])
+        assertEquals(3, progress["maximum"])
+
+        val objectRead = tools.call(
+            "save_read_object",
+            mapOf(
+                "path" to input.absolutePath,
+                "objectPath" to "tiles[0]",
+                "includeBytes" to true,
+                "byteLimit" to 6
+            )
+        )
+
+        assertFalse(objectRead.isError)
+        val content = objectRead.structuredContent.asMap()
+        assertEquals("Tile", content["type"])
+        assertEquals(16, content["absoluteByteIndex"])
+        assertEquals(14, content["byteLength"])
+
+        val properties = content["properties"].asMap()
+        assertEquals(321, properties["terrainTileId"])
+        assertEquals(654, properties["overlayTileId"])
+
+        val bytes = content["bytes"].asMap()
+        assertEquals(6, bytes["retunedLength"])
+        assertEquals("0x41 0x01 0x8E 0x02 0x68 0x03", bytes["hex"])
+    }
+
+    @Test
+    fun `property edits write a modified output save`() {
+        val input = writeSyntheticSave()
+        val output = File(input.parentFile, "edited.dat")
+        val tools = SaveMcpTools()
+
+        val result = tools.call(
+            "save_set_property",
+            mapOf(
+                "path" to input.absolutePath,
+                "objectPath" to "players[0]",
+                "property" to "displayName",
+                "value" to "Changed",
+                "outputPath" to output.absolutePath
+            )
+        )
+
+        assertFalse(result.isError)
+        assertEquals("Player One", Save().withBytes<Save>(input.readBytes().toList()).players.first().displayName)
+        assertEquals("Changed", Save().withBytes<Save>(output.readBytes().toList()).players.first().displayName)
+
+        val content = result.structuredContent.asMap()
+        assertEquals("Player One", content["before"])
+        assertEquals("Changed", content["after"])
+    }
+
+    @Test
+    fun `experience property edits preserve other unit byte bits`() {
+        val input = writeSyntheticSave()
+        val output = File(input.parentFile, "experienced.dat")
+        val tools = SaveMcpTools()
+
+        val result = tools.call(
+            "save_set_property",
+            mapOf(
+                "path" to input.absolutePath,
+                "objectPath" to "armies[0].units[0]",
+                "property" to "experienceLevel",
+                "value" to 3,
+                "outputPath" to output.absolutePath
+            )
+        )
+
+        assertFalse(result.isError)
+        val originalUnit = Save().withBytes<Save>(input.readBytes().toList()).armies.first().units.first()
+        val editedUnit = Save().withBytes<Save>(output.readBytes().toList()).armies.first().units.first()
+        assertEquals(0x12, originalUnit.stanceBits)
+        assertEquals(2, originalUnit.experienceLevel)
+        assertEquals(0x13, editedUnit.stanceBits)
+        assertEquals(3, editedUnit.experienceLevel)
+
+        val content = result.structuredContent.asMap()
+        assertEquals(2, content["before"])
+        assertEquals(3, content["after"])
+        assertEquals(147208, content["absoluteOffset"])
+    }
+
+    @Test
+    fun `experience progress edits preserve experience tier`() {
+        val input = writeSyntheticSave()
+        val output = File(input.parentFile, "progress.dat")
+        val tools = SaveMcpTools()
+
+        val result = tools.call(
+            "save_set_property",
+            mapOf(
+                "path" to input.absolutePath,
+                "objectPath" to "armies[0].units[0]",
+                "property" to "experienceProgress",
+                "value" to 3,
+                "outputPath" to output.absolutePath
+            )
+        )
+
+        assertFalse(result.isError)
+        val editedUnit = Save().withBytes<Save>(output.readBytes().toList()).armies.first().units.first()
+        assertEquals(2, editedUnit.experienceLevel)
+        assertEquals(3, editedUnit.experienceProgress)
+        assertEquals(0x1E, editedUnit.stanceBits)
+    }
+
+    @Test
+    fun `raw byte writes require explicit output and preserve input`() {
+        val input = writeSyntheticSave()
+        val output = File(input.parentFile, "raw-edited.dat")
+        val tools = SaveMcpTools()
+
+        val result = tools.call(
+            "save_write_bytes",
+            mapOf(
+                "path" to input.absolutePath,
+                "offset" to 0,
+                "values" to "41 42 43",
+                "outputPath" to output.absolutePath
+            )
+        )
+
+        assertFalse(result.isError)
+        assertEquals("TEST SAVE", Save().withBytes<Save>(input.readBytes().toList()).name)
+        assertEquals(listOf('A'.code.toByte(), 'B'.code.toByte(), 'C'.code.toByte()), output.readBytes().take(3))
+    }
+
+    @Test
+    fun `server responds to initialize and tool listing`() {
+        val server = McpStdioServer()
+        val initialize = Json.parse(
+            server.handleMessage(
+                """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}"""
+            ) ?: error("Expected response")
+        ).asMap()
+
+        val initializeResult = initialize["result"].asMap()
+        assertEquals("2025-03-26", initializeResult["protocolVersion"])
+        assertNotNull(initializeResult["serverInfo"])
+
+        val listTools = Json.parse(
+            server.handleMessage("""{"jsonrpc":"2.0","id":"tools","method":"tools/list"}""")
+                ?: error("Expected response")
+        ).asMap()
+
+        val tools = listTools["result"].asMap()["tools"].asList()
+        assertTrue(tools.any { it.asMap()["name"] == "save_read_object" })
+        assertTrue(tools.any { it.asMap()["name"] == "save_set_property" })
+    }
+
+    private fun writeSyntheticSave(): File {
+        val directory = createTempDirectory("clash-save-mcp").toFile()
+        val file = File(directory, "save.dat")
+        file.writeBytes(buildSyntheticSave())
+        return file
+    }
+
+    private fun buildSyntheticSave(): ByteArray {
+        val bytes = ByteArray(MINIMUM_REPRESENTED_SAVE_SIZE)
+
+        repeat(500) { armyIndex ->
+            writeLittleEndian(bytes, 147190 + armyIndex * 725 + 6, 0xFFFF, 2)
+        }
+        repeat(10) { castleIndex ->
+            writeLittleEndian(bytes, 509690 + castleIndex * 467 + 4, 0xFF, 1)
+            repeat(12) { slotIndex ->
+                writeLittleEndian(bytes, 509690 + castleIndex * 467 + 18 + slotIndex * 31, 0xFFFF, 2)
+            }
+        }
+
+        writeString(bytes, 0, 16, "TEST SAVE")
+        writeLittleEndian(bytes, 16, 321, 2)
+        writeLittleEndian(bytes, 18, 654, 2)
+        writeLittleEndian(bytes, 20, 872, 2)
+        writeLittleEndian(bytes, 140016, 60, 4)
+        writeLittleEndian(bytes, 140020, 40, 4)
+
+        val playerBase = 140040
+        writeLittleEndian(bytes, playerBase, 1, 4)
+        writeString(bytes, playerBase + 4, 11, "Player One")
+        bytes[playerBase + 57] = 0x0F
+
+        val armyBase = 147190
+        writeLittleEndian(bytes, armyBase, 12, 2)
+        writeLittleEndian(bytes, armyBase + 2, 34, 2)
+        writeLittleEndian(bytes, armyBase + 4, 1, 1)
+        writeLittleEndian(bytes, armyBase + 5, 6, 1)
+        writeLittleEndian(bytes, armyBase + 6, 34, 2)
+        writeLittleEndian(bytes, armyBase + 8, 1, 1)
+        writeLittleEndian(bytes, armyBase + 14, 5, 1)
+        writeLittleEndian(bytes, armyBase + 15, 80, 1)
+        writeLittleEndian(bytes, armyBase + 18, 0x12, 1)
+        writeLittleEndian(bytes, armyBase + 19, 0x04, 1)
+
+        val castleBase = 509690
+        writeLittleEndian(bytes, castleBase, 44, 1)
+        writeLittleEndian(bytes, castleBase + 1, 55, 1)
+        writeLittleEndian(bytes, castleBase + 2, 2, 1)
+        writeLittleEndian(bytes, castleBase + 4, 4, 1)
+        writeString(bytes, castleBase + 5, 10, "CastleOne")
+        repeat(12) { slotIndex ->
+            writeLittleEndian(bytes, castleBase + 402 + slotIndex, 0xFF, 1)
+        }
+        writeLittleEndian(bytes, castleBase + 402, 0, 1)
+        writeLittleEndian(bytes, castleBase + 403, 2, 1)
+
+        return bytes
+    }
+
+    private fun writeString(bytes: ByteArray, offset: Int, length: Int, value: String) {
+        val encoded = value.encodeToByteArray()
+        repeat(length) { index ->
+            bytes[offset + index] = encoded.getOrElse(index) { 0 }
+        }
+    }
+
+    private fun writeLittleEndian(bytes: ByteArray, offset: Int, value: Int, length: Int) {
+        repeat(length) { index ->
+            bytes[offset + index] = ((value ushr (index * 8)) and 0xFF).toByte()
+        }
+    }
+
+    private fun Any?.asMap(): Map<String, Any?> {
+        @Suppress("UNCHECKED_CAST")
+        return this as? Map<String, Any?> ?: error("Expected map, got ${this?.let { it::class.simpleName }}")
+    }
+
+    private fun Any?.asList(): List<Any?> {
+        return this as? List<Any?> ?: error("Expected list, got ${this?.let { it::class.simpleName }}")
+    }
+}


### PR DESCRIPTION
## Summary
- Add a stdio MCP server for Clash save inspection and modification, including schema discovery, parsed object reads, raw byte reads/writes, and property edits.
- Incorporate recovered save semantics from clash-disassembly: corrected world-view offsets, unit experience/low-morale masks, shrine/treasure tile helpers, and castle add-on metadata.
- Add deterministic map render model helpers plus regression tests and reverse-engineering documentation updates.

## Testing
- .\gradlew.bat test -x instrumentCode --no-daemon